### PR TITLE
DEV環境のGAEランタイムをgo124へアップグレード

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
     - name: Test
       run: go test -coverprofile=coverage.go.txt ./...
     - name: Upload Go coverage to Codecov

--- a/.github/workflows/gae-deploy.yml
+++ b/.github/workflows/gae-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
     - name: Get dependencies
       run: go get -v -t -d ./...
     - name: Test
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
     - name: Build
       run: go build -v ./...
     - name: Test

--- a/app.dev.yaml
+++ b/app.dev.yaml
@@ -1,4 +1,4 @@
-runtime: go121
+runtime: go124
 env: standard
 
 service: dev


### PR DESCRIPTION
## Summary
- `app.dev.yaml` のランタイムを `go121` → `go124` に更新
- #511 で `app.yaml`（本番）は更新済みだったが、`app.dev.yaml`（DEV）が漏れていた
- Google が `go121` のサポートを終了したため、DEVデプロイが失敗していた

## Test plan
- [ ] このPRマージ後、developへのデプロイ(GAE DEV)が成功することを確認