### PR TITLE
終日イベントによるCalendar同期のpanic を修正

### DIFF
--- a/server/models/google.go
+++ b/server/models/google.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"google.golang.org/api/calendar/v3"
@@ -21,19 +22,41 @@ func (e GoogleEvent) Start() time.Time { // time.Timeへのコンバータ
 	return time.Unix(e.StartTime/1000, 0)
 }
 
-func CreateEventFromCalendarAPI(cal *calendar.Event) GoogleEvent {
-	must := func(t time.Time, err error) int64 {
+// parseCalendarTime は Google Calendar API の EventDateTime からミリ秒UNIXタイムスタンプを返す。
+// 終日イベントの場合 DateTime が空で Date ("2006-01-02") が入るため、両方を考慮する。
+func parseCalendarTime(edt *calendar.EventDateTime) (int64, error) {
+	if edt.DateTime != "" {
+		t, err := time.Parse(time.RFC3339, edt.DateTime)
 		if err != nil {
-			panic(err)
+			return 0, err
 		}
-		return t.Unix() * 1000 // ミリ秒にする
+		return t.Unix() * 1000, nil
+	}
+	if edt.Date != "" {
+		t, err := time.Parse("2006-01-02", edt.Date)
+		if err != nil {
+			return 0, err
+		}
+		return t.Unix() * 1000, nil
+	}
+	return 0, fmt.Errorf("both DateTime and Date are empty")
+}
+
+func CreateEventFromCalendarAPI(cal *calendar.Event) (GoogleEvent, error) {
+	startMs, err := parseCalendarTime(cal.Start)
+	if err != nil {
+		return GoogleEvent{}, fmt.Errorf("start time parse error: %w", err)
+	}
+	endMs, err := parseCalendarTime(cal.End)
+	if err != nil {
+		return GoogleEvent{}, fmt.Errorf("end time parse error: %w", err)
 	}
 	return GoogleEvent{
 		ID:          cal.Id,
 		Title:       cal.Summary,
 		Description: cal.Description,
-		StartTime:   must(time.Parse(time.RFC3339, cal.Start.DateTime)),
-		EndTime:     must(time.Parse(time.RFC3339, cal.End.DateTime)),
+		StartTime:   startMs,
+		EndTime:     endMs,
 		Location:    cal.Location,
-	}
+	}, nil
 }

--- a/server/tasks/fetch.go
+++ b/server/tasks/fetch.go
@@ -85,7 +85,12 @@ func CronFetchGoogleEvents(w http.ResponseWriter, req *http.Request) {
 			} else {
 				updated += 1
 			}
-			ev.Google = models.CreateEventFromCalendarAPI(&item)
+			google, err := models.CreateEventFromCalendarAPI(&item)
+			if err != nil {
+				fmt.Printf("[WARN] skipping event %q (%s): %v\n", item.Summary, item.Id, err)
+				continue
+			}
+			ev.Google = google
 			if _, err := tx.Put(key, &ev); err != nil {
 				return err
 			}


### PR DESCRIPTION
Google Calendar APIでは終日イベントのDateTimeが空文字になるため、
CreateEventFromCalendarAPIでtime.Parseが失敗しpanicしていた。
これによりトランザクション全体がロールバックされ、panic以降の
イベントがDatastoreに保存されなかった。

- DateTimeが空の場合Dateフィールド("2006-01-02")をフォールバックでパース
- panicをやめてerrorを返すように変更
- fetch.goでパース失敗時はそのイベントをスキップして残りを継続

https://claude.ai/code/session_015YXYgAHhdU1xkt4NqNSYMa