### PR TITLE
chore: 前日備品連絡 cron を一時停止

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -37,10 +37,10 @@ cron:
 # }}}
 
 # {{{ Equips
-- description: 前日備品連絡
-  url: /tasks/equips/remind/bring
-  schedule: everyday 17:00
-  timezone: Asia/Tokyo
+# - description: 前日備品連絡
+#   url: /tasks/equips/remind/bring
+#   schedule: everyday 17:00
+#   timezone: Asia/Tokyo
 
 - description: Equip Report Remind (AM) 当日の 02:00-14:00 の間に開始した練習ないし試合に対して、持ち帰り報告のリマインドを投げる
   url: /tasks/equips/remind/report?from=02:00&to=14:00&channel=general


### PR DESCRIPTION
## Summary
- \`/tasks/equips/remind/bring\` (前日備品連絡, everyday 17:00 JST) を cron.yaml からコメントアウトし、一時停止する

## Test plan
- [ ] develop へのマージ後、staging で当該 cron が実行されないことを確認
- [ ] main 反映後、production の App Engine cron 一覧から当該ジョブが消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)