### PR TITLE
feat: 備品に管理方式を追加し倉庫管理備品を bring reminder から除外

### DIFF
--- a/client/models/Equip.ts
+++ b/client/models/Equip.ts
@@ -1,11 +1,13 @@
 import Member from "./Member";
 
+export type StorageType = "warehouse" | "takehome" | "";
+
 export interface EquipDraft {
   name: string;
   for_practice: boolean;
   for_game: boolean;
   description: string;
-  storage_type: string; // "warehouse" | "takehome" | ""
+  storage_type: StorageType;
 }
 
 export class Custody {
@@ -25,11 +27,11 @@ export default class Equip {
     public forGame: boolean,
     public description: string = "",
     public history: Custody[] = [],
-    public storageType: string = "",
+    public storageType: StorageType = "",
   ) { }
 
   static fromAPIResponse({ id, key, name, for_practice, for_game, description, history, storage_type }): Equip {
-    return new Equip(id, name, for_practice, for_game, description, history ?? [], storage_type ?? "");
+    return new Equip(id, name, for_practice, for_game, description, history ?? [], (storage_type ?? "") as StorageType);
   }
   static listFromAPIResponse(res: { id, key, name, for_practice, for_game, description, history, storage_type }[]): Equip[] {
     return res.map(Equip.fromAPIResponse);

--- a/client/models/Equip.ts
+++ b/client/models/Equip.ts
@@ -5,6 +5,7 @@ export interface EquipDraft {
   for_practice: boolean;
   for_game: boolean;
   description: string;
+  storage_type: string; // "warehouse" | "takehome" | ""
 }
 
 export class Custody {
@@ -24,20 +25,21 @@ export default class Equip {
     public forGame: boolean,
     public description: string = "",
     public history: Custody[] = [],
+    public storageType: string = "",
   ) { }
 
-  static fromAPIResponse({ id, key, name, for_practice, for_game, description, history }): Equip {
-    return new Equip(id, name, for_practice, for_game, description, history ?? []);
+  static fromAPIResponse({ id, key, name, for_practice, for_game, description, history, storage_type }): Equip {
+    return new Equip(id, name, for_practice, for_game, description, history ?? [], storage_type ?? "");
   }
-  static listFromAPIResponse(res: { id, key, name, for_practice, for_game, description, history }[]): Equip[] {
+  static listFromAPIResponse(res: { id, key, name, for_practice, for_game, description, history, storage_type }[]): Equip[] {
     return res.map(Equip.fromAPIResponse);
   }
 
   static draft(equip?: Equip): EquipDraft  {
     if (equip) {
-      return { name: equip.name, for_practice: equip.forPractice, for_game: equip.forGame, description: equip.description };
+      return { name: equip.name, for_practice: equip.forPractice, for_game: equip.forGame, description: equip.description, storage_type: equip.storageType ?? "" };
     }
-    return { name: "", for_practice: false, for_game: false, description: "" };
+    return { name: "", for_practice: false, for_game: false, description: "", storage_type: "" };
   }
 
   static sort(p: Equip, n: Equip): 1|-1 {

--- a/client/src/pages/equips.$id.edit.tsx
+++ b/client/src/pages/equips.$id.edit.tsx
@@ -59,6 +59,20 @@ export default function EquipEditView() {
           </div>
 
           <div className="mb-6">
+            <label className="block text-gray-700 text-sm font-bold mb-2">
+              管理方式
+            </label>
+            <select
+              value={draft.storage_type || "takehome"}
+              onChange={ev => setDraft({ ...draft, storage_type: ev.target.value })}
+              className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            >
+              <option value="takehome">持ち帰り管理（bring reminder あり）</option>
+              <option value="warehouse">倉庫管理（bring reminder なし）</option>
+            </select>
+          </div>
+
+          <div className="mb-6">
             <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="description">
               詳細説明 (任意)
             </label>

--- a/client/src/pages/equips.$id.edit.tsx
+++ b/client/src/pages/equips.$id.edit.tsx
@@ -64,7 +64,7 @@ export default function EquipEditView() {
             </label>
             <select
               value={draft.storage_type || "takehome"}
-              onChange={ev => setDraft({ ...draft, storage_type: ev.target.value })}
+              onChange={ev => setDraft({ ...draft, storage_type: ev.target.value as import("../../models/Equip").StorageType })}
               className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
             >
               <option value="takehome">持ち帰り管理（bring reminder あり）</option>

--- a/client/src/pages/equips.$id.tsx
+++ b/client/src/pages/equips.$id.tsx
@@ -26,6 +26,10 @@ export default function Item() {
             <h1 className="text-2xl font-bold">{equip.name}</h1>
             {equip.forPractice ? <span className="rounded-md bg-teal-600   mr-2 text-white px-2">練習で必要</span> : null}
             {equip.forGame ?     <span className="rounded-md bg-orange-600 mr-2 text-white px-2">試合で必要</span> : null}
+            {equip.storageType === "warehouse"
+              ? <span className="rounded-md bg-gray-500 mr-2 text-white px-2">倉庫管理</span>
+              : <span className="rounded-md bg-blue-500 mr-2 text-white px-2">持ち帰り管理</span>
+            }
           </div>
 
           <div className="mb-4 text-gray-400 text-sm">

--- a/client/src/pages/equips.create.tsx
+++ b/client/src/pages/equips.create.tsx
@@ -44,6 +44,20 @@ export default function CreateItem() {
           </div>
 
           <div className="mb-6">
+            <label className="block text-gray-700 text-sm font-bold mb-2">
+              管理方式
+            </label>
+            <select
+              value={draft.storage_type}
+              onChange={ev => setDraft({ ...draft, storage_type: ev.target.value })}
+              className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            >
+              <option value="takehome">持ち帰り管理（bring reminder あり）</option>
+              <option value="warehouse">倉庫管理（bring reminder なし）</option>
+            </select>
+          </div>
+
+          <div className="mb-6">
             <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="description">
               詳細説明 (任意)
             </label>

--- a/client/src/pages/equips.create.tsx
+++ b/client/src/pages/equips.create.tsx
@@ -49,7 +49,7 @@ export default function CreateItem() {
             </label>
             <select
               value={draft.storage_type}
-              onChange={ev => setDraft({ ...draft, storage_type: ev.target.value })}
+              onChange={ev => setDraft({ ...draft, storage_type: ev.target.value as import("../../models/Equip").StorageType })}
               className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
             >
               <option value="takehome">持ち帰り管理（bring reminder あり）</option>

--- a/client/src/pages/equips.tsx
+++ b/client/src/pages/equips.tsx
@@ -16,46 +16,48 @@ export default function List() {
   useEffect(() => {
     repo.list().then(setEquips);
   }, [repo]);
+
+  const takeHome = equips.filter(e => e.storageType !== "warehouse").sort(Equip.sort);
+  const warehouse = equips.filter(e => e.storageType === "warehouse").sort(Equip.sort);
+
   return (
     <Layout>
-      <div className="shadow overflow-hidden border border-gray-200 sm:rounded-lg mb-14">
-        <table className="min-w-full divide-y divide-gray-200">
-          <tbody>
-            {equips.sort(Equip.sort).map((eq, i) => <EquipItem
-              key={eq.id} equip={eq} border={i < equips.length - 1}
-              jump={() => navigate({ to: `/equips/${eq.id}` })}
-            />)}
-          </tbody>
-        </table>
-      </div>
-      <div
-        className="
-        px-4 sm:px-6 lg:px-8
-        py-4
+      <EquipSection title="持ち帰り管理" equips={takeHome} navigate={navigate} />
+      <EquipSection title="倉庫管理"     equips={warehouse} navigate={navigate} />
+      <div className="
+        px-4 sm:px-6 lg:px-8 py-4
         fixed left-0 bottom-0
         w-full flex flex-row-reverse
         space-x-4 space-x-reverse
-        "
-      >
+      ">
         <div
-          className="
-            basis-1/3
-            text-center bg-blue-700 text-white p-2 rounded-md
-            shadow-md shadow-gray-500
-          "
+          className="basis-1/3 text-center bg-blue-700 text-white p-2 rounded-md shadow-md shadow-gray-500"
           onClick={() => navigate({ to: "/equips/report" })}
         >回収報告</div>
         {myself?.slack?.profile?.title?.match(/staff/i) ? <div
-          className="
-            basis-2/3
-            text-center bg-red-900 text-white p-2 rounded-md
-            shadow-md shadow-gray-500
-          "
+          className="basis-2/3 text-center bg-red-900 text-white p-2 rounded-md shadow-md shadow-gray-500"
           onClick={() => navigate({ to: "/equips/create" })}
         >新規アイテム登録</div> : null}
       </div>
     </Layout>
   )
+}
+
+function EquipSection({ title, equips, navigate }: { title: string, equips: Equip[], navigate: any }) {
+  if (equips.length === 0) return null;
+  return (
+    <div className="shadow overflow-hidden border border-gray-200 sm:rounded-lg mb-4">
+      <div className="px-4 py-2 bg-gray-50 text-sm font-medium text-gray-500 border-b border-gray-200">{title}</div>
+      <table className="min-w-full divide-y divide-gray-200">
+        <tbody>
+          {equips.map((eq, i) => <EquipItem
+            key={eq.id} equip={eq} border={i < equips.length - 1}
+            jump={() => navigate({ to: `/equips/${eq.id}` })}
+          />)}
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 function Circle({ type }: { type: "practice" | "game" }) {
@@ -68,7 +70,7 @@ function Circle({ type }: { type: "practice" | "game" }) {
   }
 }
 
-function EquipItem({ equip, jump, border }: { equip: Equip, jump, border: boolean }) {
+function EquipItem({ equip, jump, border }: { equip: Equip, jump: () => void, border: boolean }) {
   const [m, setMember] = useState<Member>(null)
   useEffect(() => {
     if (equip.history.length == 0) return;

--- a/server/models/equip.go
+++ b/server/models/equip.go
@@ -8,6 +8,13 @@ import (
 	"cloud.google.com/go/datastore"
 )
 
+type StorageType string
+
+const (
+	StorageTypeWarehouse StorageType = "warehouse"
+	StorageTypeTakeHome  StorageType = "takehome"
+)
+
 type (
 	Equip struct {
 		ID          int64          `json:"id" datastore:"-"`
@@ -17,9 +24,7 @@ type (
 		ForGame     bool           `json:"for_game"`
 		Description string         `json:"description"`
 		History     []Custody      `json:"history" datastore:"-"`
-		// StorageType 備品の管理方式。"warehouse"=倉庫管理、"takehome"=持ち帰り管理。
-		// 空文字（未設定）は後方互換のため "takehome" 扱い。
-		StorageType string `json:"storage_type"`
+		StorageType StorageType    `json:"storage_type"`
 	}
 
 	Custody struct {

--- a/server/models/equip.go
+++ b/server/models/equip.go
@@ -17,6 +17,9 @@ type (
 		ForGame     bool           `json:"for_game"`
 		Description string         `json:"description"`
 		History     []Custody      `json:"history" datastore:"-"`
+		// StorageType 備品の管理方式。"warehouse"=倉庫管理、"takehome"=持ち帰り管理。
+		// 空文字（未設定）は後方互換のため "takehome" 扱い。
+		StorageType string `json:"storage_type"`
 	}
 
 	Custody struct {

--- a/server/tasks/equips.go
+++ b/server/tasks/equips.go
@@ -80,7 +80,7 @@ func EquipsRemindBring(w http.ResponseWriter, req *http.Request) {
 	// 4) 必要なequipの場合は所有者を取得する
 	targets := []models.Equip{}
 	for i, eq := range equips {
-		if eq.StorageType == "warehouse" {
+		if eq.StorageType == models.StorageTypeWarehouse {
 			continue
 		}
 		if !eq.ShouldBringFor(ev) {

--- a/server/tasks/equips.go
+++ b/server/tasks/equips.go
@@ -80,6 +80,9 @@ func EquipsRemindBring(w http.ResponseWriter, req *http.Request) {
 	// 4) 必要なequipの場合は所有者を取得する
 	targets := []models.Equip{}
 	for i, eq := range equips {
+		if eq.StorageType == "warehouse" {
+			continue
+		}
 		if !eq.ShouldBringFor(ev) {
 			continue
 		}


### PR DESCRIPTION
## Summary

備品に「倉庫管理 / 持ち帰り管理」の概念を追加し、倉庫管理備品をすべての Slack 通知から除外する。

## Changes

### モデル・バックエンド
- `Equip` モデルに `StorageType` フィールドを追加
  - `StorageTypeWarehouse = "warehouse"` / `StorageTypeTakeHome = "takehome"`
  - 空文字（既存レコード）は後方互換で `"takehome"` 扱い
- 以下の3 cron すべてで `warehouse` 備品をスキップ:
  - `EquipsRemindBring` — 前日「持ってきて」リマインド
  - `EquipsRemindReportAfterEvent` — 当日「持ち帰ったら報告して」リマインド
  - `EquipsScanUnreported` — 未報告備品アラート
- `StorageType` を Go 型定数・TS ユニオン型に昇格（マジックストリング廃止）

### フロントエンド
- 備品作成 / 編集ページに「管理方式」セレクタを追加
- 備品詳細ページに管理方式バッジを追加（グレー: 倉庫管理 / ブルー: 持ち帰り管理）
- 備品一覧を「持ち帰り管理」「倉庫管理」の2セクションに分割（空セクションは非表示）

## Test Plan

- [ ] [UI][MUTATING] 備品編集ページで「管理方式」を「倉庫管理」に設定して保存できる
- [ ] [UI][MUTATING] 備品作成ページで「管理方式」として「倉庫管理」または「持ち帰り管理」を選択できる
- [ ] [UI] 備品詳細ページに管理方式バッジが表示される（倉庫管理: グレー / 持ち帰り管理: ブルー）
- [ ] [UI] 備品一覧が「持ち帰り管理」「倉庫管理」セクションに分割される
- [ ] [UI] 片方のセクションが空の場合は非表示になる
- [ ] [LOGIC] `StorageType="warehouse"` の備品は3つの cron すべての通知対象に含まれない
- [ ] [LOGIC] `StorageType="takehome"` または空文字の備品は引き続き通知対象に含まれる
- [ ] [BUILD] `go build -v ./...` がエラーなく完了する ✅
- [ ] [BUILD] `npm run build` がエラーなく完了する ✅

Closes #562