### PR TITLE
chore: env-provision スクリプト追加・CLAUDE.md に env_provisioner 宣言

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+env_provisioner: scripts/env-provision
+---
+
 # CLAUDE.md
 
 ## Project Overview

--- a/scripts/env-provision
+++ b/scripts/env-provision
@@ -25,6 +25,38 @@ _workdir() {
   echo "/tmp/hub-env-${1}"
 }
 
+# git worktree 内で実行中なら main リポジトリのルートを返す。
+# main リポジトリ自身なら $REPO_ROOT をそのまま返す。
+_main_repo_root() {
+  local common
+  common=$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)
+  if [[ "$common" = ".git" ]]; then
+    echo "$REPO_ROOT"
+  else
+    # worktree: common は /path/to/main/.git (絶対パス)
+    echo "${common%/.git}"
+  fi
+}
+
+# worktree 内で gitignore 対象ファイルをメインリポジトリからシンボリックリンクで補完する。
+# 冪等（既にリンク or ファイルが存在すればスキップ）。
+_setup_worktree_symlinks() {
+  local main_root
+  main_root=$(_main_repo_root)
+  [[ "$main_root" == "$REPO_ROOT" ]] && return 0  # main リポジトリ自身なら何もしない
+
+  # node_modules
+  [[ -e "${REPO_ROOT}/node_modules" ]] || \
+    ln -s "${main_root}/node_modules" "${REPO_ROOT}/node_modules"
+
+  # secrets.local.yaml
+  [[ -e "${REPO_ROOT}/secrets.local.yaml" ]] || \
+    ln -s "${main_root}/secrets.local.yaml" "${REPO_ROOT}/secrets.local.yaml"
+
+  # client/dest（marmoset.LoadViews が init で要求する。Vite が配信するので中身は不要）
+  mkdir -p "${REPO_ROOT}/client/dest"
+}
+
 # ------------------------------------------------------------------ doctor ---
 _doctor() {
   local ok=true
@@ -71,6 +103,9 @@ _provision() {
   local datadir="${REPO_ROOT}/devdata/env-${id}"
 
   mkdir -p "$workdir" "$datadir"
+
+  # --- worktree 補完（node_modules・secrets・client/dest のシンボリックリンク）---
+  _setup_worktree_symlinks
 
   # --- Datastore Emulator 起動 ---
   gcloud beta emulators datastore start \

--- a/scripts/env-provision
+++ b/scripts/env-provision
@@ -92,9 +92,18 @@ _provision() {
     sleep 1
   done
 
-  # --- Go API サーバ起動 ---
+  # --- フロントエンドビルド ---
+  # VITE_API_BASE_URL はデフォルト "" (同オリジン相対パス) のため、
+  # ビルドした SPA を Go が配信すれば /api/1/... は api_port に届く。
+  # Vite dev server (port 3000) は使わず、Go が client/dest/ を静的配信する構成。
+  (cd "${REPO_ROOT}" && npm run build) > "${workdir}/build.log" 2>&1 || {
+    printf '{"ready":false,"id":"%s","diagnostics":["npm run build failed. See %s/build.log"]}\n' \
+      "$id" "$workdir"
+    exit 1
+  }
+
+  # --- Go サーバ起動（API + SPA 静的配信を兼務）---
   # secrets.local.yaml は Go の init() 内で appyaml.Load() により自動ロードされる。
-  # ここでは Datastore 接続先とポートだけ上書きする。
   PORT="${api_port}" \
   DATASTORE_EMULATOR_HOST="localhost:${ds_port}" \
   DATASTORE_PROJECT_ID="${PROJECT_ID}" \
@@ -105,23 +114,17 @@ _provision() {
     > "${workdir}/api.log" 2>&1 &
   echo $! > "${workdir}/api.pid"
 
-  # API サーバの起動を待つ（最大 30 秒）
+  # サーバの起動を待つ（最大 30 秒）
   retries=30
   while ! nc -z localhost "${api_port}" 2>/dev/null; do
     retries=$((retries - 1))
     if [[ $retries -le 0 ]]; then
-      printf '{"ready":false,"id":"%s","diagnostics":["Go API server timed out on port %s. See %s/api.log"]}\n' \
+      printf '{"ready":false,"id":"%s","diagnostics":["Go server timed out on port %s. See %s/api.log"]}\n' \
         "$id" "$api_port" "$workdir"
       exit 1
     fi
     sleep 1
   done
-
-  # TODO: /uat がブラウザ UI テストを行う場合は npm run build で SPA をビルドし、
-  #       Go に静的ファイルを配信させること（go run main.go は client/dest/ を参照する）。
-  #       現状、Go が client/dest/index.html を見つけられない場合は API のみのテストとなる。
-  #       必要なら下記のコメントを外す:
-  # (cd "${REPO_ROOT}" && npm run build) 2>&1 | tee "${workdir}/build.log"
 
   printf '{"ready":true,"id":"%s","endpoints":{"app":"http://localhost:%s","api":"http://localhost:%s/api/1","datastore":"http://localhost:%s"},"diagnostics":[]}\n' \
     "$id" "$api_port" "$api_port" "$ds_port"

--- a/scripts/env-provision
+++ b/scripts/env-provision
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# env-contract 準拠の env_provisioner
+# スタック: Go + Node.js + Datastore Emulator (Docker Compose なし)
+# 生成元: /bootstrap
+set -euo pipefail
+
+VERB="${1:-}"
+ID="${2:-}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_ID="${PROJECT_ID:-triax-football}"
+
+if [[ -z "$VERB" ]]; then
+  echo "Usage: $0 <verb> [<id>]" >&2
+  echo "  verbs: provision, doctor, teardown, status" >&2
+  exit 1
+fi
+
+# ID から 0-99 のオフセットを算出（並列 env 間のポート衝突を回避）
+_port_offset() {
+  printf '%s' "${1}" | cksum | awk '{print $1 % 100}'
+}
+
+# PID / ログの作業ディレクトリ
+_workdir() {
+  echo "/tmp/hub-env-${1}"
+}
+
+# ------------------------------------------------------------------ doctor ---
+_doctor() {
+  local ok=true
+  local issues=()
+
+  _check() {
+    local name="$1" cmd="$2" detail_ok="$3" detail_fail="$4" fix="$5"
+    if eval "$cmd" >/dev/null 2>&1; then
+      issues+=("{\"check\":\"${name}\",\"status\":\"pass\",\"detail\":\"${detail_ok}\"}")
+    else
+      ok=false
+      issues+=("{\"check\":\"${name}\",\"status\":\"fail\",\"detail\":\"${detail_fail}\",\"remediation\":\"${fix}\"}")
+    fi
+  }
+
+  _check "gcloud"          "command -v gcloud"      "gcloud CLI found" "gcloud CLI not found"          "Install Google Cloud SDK"
+  _check "datastore-comp"  "gcloud components list --format='value(id)' 2>/dev/null | grep -q cloud-datastore-emulator" \
+                                                    "cloud-datastore-emulator installed" "cloud-datastore-emulator not installed" \
+                                                    "gcloud components install cloud-datastore-emulator"
+  _check "go"              "command -v go"          "go found"          "go not found"                  "Install Go"
+  _check "npm"             "command -v npm"          "npm found"         "npm not found"                 "Install Node.js"
+  _check "secrets"         "test -f '${REPO_ROOT}/secrets.local.yaml'" \
+                                                    "secrets.local.yaml found" "secrets.local.yaml not found" \
+                                                    "cp secrets.example.yaml secrets.local.yaml && fill in values"
+
+  local checks_json
+  local joined
+  joined=$(printf '%s,' "${issues[@]}")
+  checks_json="[${joined%,}]"
+  printf '{"ok":%s,"checks":%s}\n' "$ok" "$checks_json"
+}
+
+# --------------------------------------------------------------- provision ---
+_provision() {
+  local id="$1"
+  local offset
+  offset=$(_port_offset "$id")
+
+  # cross-ref 不可侵性: id ごとに独立したポートとデータディレクトリを使う
+  local ds_port=$((9100 + offset * 2))      # Datastore Emulator ポート
+  local api_port=$((9101 + offset * 2))     # Go API ポート
+  local workdir
+  workdir=$(_workdir "$id")
+  local datadir="${REPO_ROOT}/devdata/env-${id}"
+
+  mkdir -p "$workdir" "$datadir"
+
+  # --- Datastore Emulator 起動 ---
+  gcloud beta emulators datastore start \
+    --data-dir="$datadir" \
+    --project="${PROJECT_ID}" \
+    --host-port="localhost:${ds_port}" \
+    > "${workdir}/datastore.log" 2>&1 &
+  echo $! > "${workdir}/datastore.pid"
+
+  # エミュレータの起動を待つ（最大 30 秒）
+  local retries=30
+  while ! curl -sf "http://localhost:${ds_port}/" >/dev/null 2>&1; do
+    retries=$((retries - 1))
+    if [[ $retries -le 0 ]]; then
+      printf '{"ready":false,"id":"%s","diagnostics":["Datastore emulator timed out on port %s. See %s/datastore.log"]}\n' \
+        "$id" "$ds_port" "$workdir"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  # --- Go API サーバ起動 ---
+  # secrets.local.yaml は Go の init() 内で appyaml.Load() により自動ロードされる。
+  # ここでは Datastore 接続先とポートだけ上書きする。
+  PORT="${api_port}" \
+  DATASTORE_EMULATOR_HOST="localhost:${ds_port}" \
+  DATASTORE_PROJECT_ID="${PROJECT_ID}" \
+  DATASTORE_DATASET="${PROJECT_ID}" \
+  DATASTORE_EMULATOR_HOST_PATH="localhost:${ds_port}/datastore" \
+  DATASTORE_HOST="http://localhost:${ds_port}" \
+    go run "${REPO_ROOT}/main.go" \
+    > "${workdir}/api.log" 2>&1 &
+  echo $! > "${workdir}/api.pid"
+
+  # API サーバの起動を待つ（最大 30 秒）
+  retries=30
+  while ! nc -z localhost "${api_port}" 2>/dev/null; do
+    retries=$((retries - 1))
+    if [[ $retries -le 0 ]]; then
+      printf '{"ready":false,"id":"%s","diagnostics":["Go API server timed out on port %s. See %s/api.log"]}\n' \
+        "$id" "$api_port" "$workdir"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  # TODO: /uat がブラウザ UI テストを行う場合は npm run build で SPA をビルドし、
+  #       Go に静的ファイルを配信させること（go run main.go は client/dest/ を参照する）。
+  #       現状、Go が client/dest/index.html を見つけられない場合は API のみのテストとなる。
+  #       必要なら下記のコメントを外す:
+  # (cd "${REPO_ROOT}" && npm run build) 2>&1 | tee "${workdir}/build.log"
+
+  printf '{"ready":true,"id":"%s","endpoints":{"app":"http://localhost:%s","api":"http://localhost:%s/api/1","datastore":"http://localhost:%s"},"diagnostics":[]}\n' \
+    "$id" "$api_port" "$api_port" "$ds_port"
+}
+
+# --------------------------------------------------------------- teardown ---
+_teardown() {
+  local id="$1"
+  local workdir
+  workdir=$(_workdir "$id")
+
+  # PID ファイルにあるプロセスを全て停止
+  for pidfile in "${workdir}"/*.pid; do
+    [[ -f "$pidfile" ]] || continue
+    local pid
+    pid=$(cat "$pidfile")
+    # 子プロセスごとグループを停止
+    kill -- -"$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')" 2>/dev/null || kill "$pid" 2>/dev/null || true
+    rm -f "$pidfile"
+  done
+
+  # emulator データと作業ディレクトリを削除
+  rm -rf "${REPO_ROOT}/devdata/env-${id}"
+  rm -rf "$workdir"
+}
+
+# ----------------------------------------------------------------- status ---
+_status() {
+  local id="$1"
+  local workdir
+  workdir=$(_workdir "$id")
+  local running=0
+
+  for pidfile in "${workdir}"/*.pid; do
+    [[ -f "$pidfile" ]] || continue
+    local pid
+    pid=$(cat "$pidfile")
+    if kill -0 "$pid" 2>/dev/null; then
+      running=$((running + 1))
+    fi
+  done
+
+  printf '{"id":"%s","running_processes":%s}\n' "$id" "$running"
+}
+
+# ---------------------------------------------------------------- dispatch ---
+case "$VERB" in
+  provision)  _provision "$ID" ;;
+  doctor)     _doctor ;;
+  teardown)   _teardown "$ID" ;;
+  status)     _status "$ID" ;;
+  *)
+    echo "Unknown verb: $VERB" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/env-provision
+++ b/scripts/env-provision
@@ -92,17 +92,9 @@ _provision() {
     sleep 1
   done
 
-  # --- フロントエンドビルド ---
-  # VITE_API_BASE_URL はデフォルト "" (同オリジン相対パス) のため、
-  # ビルドした SPA を Go が配信すれば /api/1/... は api_port に届く。
-  # Vite dev server (port 3000) は使わず、Go が client/dest/ を静的配信する構成。
-  (cd "${REPO_ROOT}" && npm run build) > "${workdir}/build.log" 2>&1 || {
-    printf '{"ready":false,"id":"%s","diagnostics":["npm run build failed. See %s/build.log"]}\n' \
-      "$id" "$workdir"
-    exit 1
-  }
+  local vite_port=$((3100 + offset))   # Vite dev server ポート（HMR 有効）
 
-  # --- Go サーバ起動（API + SPA 静的配信を兼務）---
+  # --- Go API サーバ起動 ---
   # secrets.local.yaml は Go の init() 内で appyaml.Load() により自動ロードされる。
   PORT="${api_port}" \
   DATASTORE_EMULATOR_HOST="localhost:${ds_port}" \
@@ -114,20 +106,40 @@ _provision() {
     > "${workdir}/api.log" 2>&1 &
   echo $! > "${workdir}/api.pid"
 
-  # サーバの起動を待つ（最大 30 秒）
+  # API サーバの起動を待つ（最大 30 秒）
   retries=30
   while ! nc -z localhost "${api_port}" 2>/dev/null; do
     retries=$((retries - 1))
     if [[ $retries -le 0 ]]; then
-      printf '{"ready":false,"id":"%s","diagnostics":["Go server timed out on port %s. See %s/api.log"]}\n' \
+      printf '{"ready":false,"id":"%s","diagnostics":["Go API server timed out on port %s. See %s/api.log"]}\n' \
         "$id" "$api_port" "$workdir"
       exit 1
     fi
     sleep 1
   done
 
+  # --- Vite dev server 起動（HMR 有効・proxy → api_port）---
+  # VITE_PORT / VITE_API_PORT は vite.config.ts で参照される。
+  VITE_PORT="${vite_port}" \
+  VITE_API_PORT="${api_port}" \
+    npm --prefix "${REPO_ROOT}" run dev \
+    > "${workdir}/vite.log" 2>&1 &
+  echo $! > "${workdir}/vite.pid"
+
+  # Vite の起動を待つ（最大 30 秒）
+  retries=30
+  while ! nc -z localhost "${vite_port}" 2>/dev/null; do
+    retries=$((retries - 1))
+    if [[ $retries -le 0 ]]; then
+      printf '{"ready":false,"id":"%s","diagnostics":["Vite dev server timed out on port %s. See %s/vite.log"]}\n' \
+        "$id" "$vite_port" "$workdir"
+      exit 1
+    fi
+    sleep 1
+  done
+
   printf '{"ready":true,"id":"%s","endpoints":{"app":"http://localhost:%s","api":"http://localhost:%s/api/1","datastore":"http://localhost:%s"},"diagnostics":[]}\n' \
-    "$id" "$api_port" "$api_port" "$ds_port"
+    "$id" "$vite_port" "$api_port" "$ds_port"
 }
 
 # --------------------------------------------------------------- teardown ---

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const apiBase = `http://localhost:${process.env.VITE_API_PORT ?? '8080'}`
+
 export default defineConfig({
   plugins: [react()],
   root: 'client',
@@ -12,12 +14,12 @@ export default defineConfig({
     passWithNoTests: true,
   },
   server: {
-    port: 3000,
+    port: parseInt(process.env.VITE_PORT ?? '3000'),
     proxy: {
-      '/api': 'http://localhost:8080',
-      '/auth': 'http://localhost:8080',
-      '/login': 'http://localhost:8080',
-      '/logout': 'http://localhost:8080',
+      '/api':    apiBase,
+      '/auth':   apiBase,
+      '/login':  apiBase,
+      '/logout': apiBase,
     },
   },
 })


### PR DESCRIPTION
## Summary

- `/bootstrap` により Go + Datastore Emulator スタック向けの `scripts/env-provision` を生成
- `CLAUDE.md` 先頭に frontmatter を追加し `env_provisioner: scripts/env-provision` を宣言
- これにより `/tackle` と `/uat` が隔離された Datastore Emulator + Go API 環境で自動検証できるようになる

## 分離方式

| コンポーネント | 分離方法 |
|---|---|
| Datastore Emulator | `cksum(id) % 100` で算出した固有ポート（9100〜9298） |
| Go API サーバ | 同オフセットで固有ポート（9101〜9299） |
| データディレクトリ | `devdata/env-<id>/` に独立 |

## Test Plan

- [ ] `./scripts/env-provision doctor` が JSON を返すこと
- [ ] `./scripts/env-provision provision test-1` で Datastore Emulator と Go API が起動すること
- [ ] `./scripts/env-provision status test-1` で running_processes > 0 が返ること
- [ ] `./scripts/env-provision teardown test-1` でプロセスが停止・ディレクトリが削除されること
- [ ] `provision` を並列実行したとき（`test-1` と `test-2`）ポートが衝突しないこと