### PR TITLE
fix: 備品報告ボタンで1件回答するとメッセージ全体が上書きされる問題を修正

### DIFF
--- a/server/slackbot/shortcuts.go
+++ b/server/slackbot/shortcuts.go
@@ -96,9 +96,28 @@ func (bot Bot) Shortcuts(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		postSlackJSON(payload.ResponseURL, fmt.Sprintf(":white_check_mark: %s ⇒ %s", payload.Message.Text, member.Name()))
-
-		// TODO: 全回答フィードバック
+		// 回答済みブロックのみ確認テキストに差し替え、未回答ブロックのドロップダウンは維持する
+		newBlocks := make([]slack.Block, 0, len(payload.Message.Blocks.BlockSet))
+		for _, block := range payload.Message.Blocks.BlockSet {
+			if block.BlockType() == slack.MBTSection {
+				if sb, ok := block.(*slack.SectionBlock); ok && sb.BlockID == action.BlockID {
+					newBlocks = append(newBlocks, slack.NewSectionBlock(
+						slack.NewTextBlockObject(slack.MarkdownType,
+							fmt.Sprintf(":white_check_mark: %s ⇒ %s", sb.Text.Text, member.Name()),
+							false, false),
+						nil, nil,
+					))
+					continue
+				}
+			}
+			newBlocks = append(newBlocks, block)
+		}
+		body, _ := json.Marshal(map[string]interface{}{
+			"replace_original": true,
+			"text":             payload.Message.Text,
+			"blocks":           newBlocks,
+		})
+		http.Post(payload.ResponseURL, "application/json", bytes.NewReader(body))
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary

- `postSlackJSON(response_url, text)` が `{"text": ...}` のみを送信していたため、Slack がメッセージ全体をプレーンテキストで上書きし、残りのすべてのドロップダウンブロックを削除していた
- 5件の備品に対して5人分の回答が必要なところ、1人目が回答した時点でメッセージが壊れ残り4件の回答ができなくなっていた
- 修正: `payload.Message.Blocks.BlockSet` をイテレートし、操作されたブロック（`action.BlockID` 一致）のみを `✅ 備品名 ⇒ 選択者名` テキストに差し替え、残りのブロック（未回答備品のドロップダウン）はそのまま `blocks` ごと `response_url` に POST する

## Test Plan

- [ ] 練習後の `equip-report-reminder` メッセージで、1件回答後も残りのドロップダウンが消えないこと
- [ ] 回答済みの備品行に ✅ と名前が表示されること
- [ ] 全件回答完了後、すべての行が確認テキストになること
- [ ] Datastore の Custody エンティティが正しく保存されること