### PR TITLE
fix(taping): /taping・/events/{id}/taping を全メンバーアクセス可能に変更

### DIFF
--- a/client/src/pages/events.$id.taping.tsx
+++ b/client/src/pages/events.$id.taping.tsx
@@ -1,6 +1,6 @@
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams } from "@tanstack/react-router"; // useNavigate は下部ボタンで使用
 import { useEffect, useMemo, useState } from "react";
-import { isTapingManager } from "../utils/tapingAuth";
+import { isTapingManager } from "../utils/tapingAuth"; // 全体集計セクションの表示判定にのみ使用
 import Layout from "../../components/layout";
 import Taping from "../../models/Taping";
 import Member from "../../models/Member";
@@ -22,11 +22,10 @@ export default function EventTaping() {
 
   useEffect(() => {
     if (!myself?.slack?.id || myself.slack.id === "xxx") return;
-    if (!isTapingManager(myself)) { navigate({ to: "/" }); return; }
     if (!id) return;
     eventRepo.get(id).then(setEvent);
     tapingRepo.listRequests(id).then(setTapings);
-  }, [id, myself, tapingRepo, eventRepo, navigate]);
+  }, [id, myself, tapingRepo, eventRepo]);
 
   const byMember = tapings.reduce<Record<string, Taping[]>>((acc, t) => {
     (acc[t.memberID] ||= []).push(t);

--- a/client/src/pages/taping.tsx
+++ b/client/src/pages/taping.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 import Layout from "../../components/layout";
-import { isTapingManager } from "../utils/tapingAuth";
+import { isTapingManager } from "../utils/tapingAuth"; // マスタ管理ボタンの表示判定にのみ使用
 import Taping from "../../models/Taping";
 import TapeItem from "../../models/TapeItem";
 import Member from "../../models/Member";
@@ -24,8 +24,6 @@ export default function TapingOverview() {
 
   useEffect(() => {
     if (!myself?.slack?.id || myself.slack.id === "xxx") return;
-    if (!isTapingManager(myself)) { navigate({ to: "/" }); return; }
-
     repo.listRequests(undefined, year).then(setYearTapings);
     repo.tapeItemList().then(setTapeItems);
     repo.listEvents().then(evs => {
@@ -38,8 +36,6 @@ export default function TapingOverview() {
   }, [myself, navigate, repo, year]);
 
   const activeTapeItems = useMemo(() => tapeItems.filter(t => !t.disabled), [tapeItems]);
-
-  if (myself?.slack?.id && myself.slack.id !== "xxx" && !isTapingManager(myself)) return null;
 
   // --- 費用集計（年度累計） ---
   const costByMember = yearTapings.reduce<Record<string, { price: number; count: number }>>((acc, t) => {

--- a/server/api/taping.go
+++ b/server/api/taping.go
@@ -427,18 +427,12 @@ func GetMyTapingRequest(w http.ResponseWriter, req *http.Request) {
 func ListTapingRequests(w http.ResponseWriter, req *http.Request) {
 	render := marmoset.Render(w)
 	ctx := req.Context()
-	slackID := filters.GetSessionUserContext(req)
 	client, err := datastore.NewClient(ctx, os.Getenv("GOOGLE_CLOUD_PROJECT"))
 	if err != nil {
 		render.JSON(http.StatusInternalServerError, marmoset.P{"error": err.Error()})
 		return
 	}
 	defer client.Close()
-
-	if ok, err := isTapingManager(ctx, slackID, client); err != nil || !ok {
-		render.JSON(http.StatusForbidden, marmoset.P{"error": "forbidden"})
-		return
-	}
 
 	query := datastore.NewQuery(models.KindTaping)
 	if eventID := req.URL.Query().Get("event_id"); eventID != "" {


### PR DESCRIPTION
## Summary

- `/taping`（年度集計・在庫状況）と `/events/{id}/taping`（イベント別リクエスト一覧）のアクセス制御を緩和
- PR #571 で admin/trainer/staff のみアクセス可能としていたが、チーム内で共有すべき情報のため全ログインメンバーが閲覧できるよう変更

## Changes

- `client/src/pages/taping.tsx` — `isTapingManager` リダイレクトガードを除去（マスタ管理ボタン表示判定には引き続き使用）
- `client/src/pages/events.$id.taping.tsx` — 同上
- `server/api/taping.go` — `ListTapingRequests` の admin/trainer チェックを除去

## Access Control After This Change

| ページ | アクセス可能なユーザー |
|---|---|
| `/taping/request` | 全ログインメンバー |
| `/taping` | 全ログインメンバー |
| `/events/{id}/taping` | 全ログインメンバー |
| `/taping/master` | Admin / Trainer / Staff のみ（変更なし） |