### PR TITLE
fix(taping): イベントセレクトを練習・試合のみに絞り込む

### DIFF
--- a/server/api/taping.go
+++ b/server/api/taping.go
@@ -469,13 +469,20 @@ func ListTapingEvents(w http.ResponseWriter, req *http.Request) {
 	defer client.Close()
 
 	from := time.Now().Add(-40 * 24 * time.Hour).Unix() * 1000
-	events := []models.Event{}
+	all := []models.Event{}
 	if _, err := client.GetAll(ctx,
 		datastore.NewQuery(models.KindEvent).Filter("Google.StartTime >", from).Order("Google.StartTime"),
-		&events,
+		&all,
 	); err != nil && !models.IsFiledMismatch(err) {
 		render.JSON(http.StatusInternalServerError, marmoset.P{"error": err.Error()})
 		return
+	}
+	// テーピングが必要なのは練習・試合のみ
+	events := []models.Event{}
+	for _, ev := range all {
+		if ev.IsPractice() || ev.IsGame() {
+			events = append(events, ev)
+		}
 	}
 	render.JSON(http.StatusOK, events)
 }


### PR DESCRIPTION
## Summary

`/taping/request` のイベントセレクトに #mtg・#ignore・#event 系のイベントが混入していた問題を修正。

## Root Cause

`ListTapingEvents` が Datastore から全イベントをそのまま返していた。

## Fix

取得後に `ev.IsPractice() || ev.IsGame()` でフィルタリング。

## Test Plan

- [ ] [UI] `/taping/request` のイベントセレクトに練習・試合のみ表示されること
- [ ] [UI] `#mtg`・`#ignore`・`#event` タグのイベントが表示されないこと
- [x] [BUILD] `go build ./...` 成功