### PR TITLE
chore: デプロイフローを main ベース・タグリリースに移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,11 @@ npm run lint         # ESLint
 
 ## Git Workflow
 
-- `main` — production (auto-deploys to GAE on merge)
-- `develop` — staging (PRs from develop to main trigger dev deploy)
-- Feature branches → PR to `develop` or `main`
+- `main` — DEV 環境に自動デプロイ（push 時）
+- `v*` タグ — PROD 環境に自動デプロイ（任意のリビジョンにタグを打てば deploy される）
+- Feature branches → PR to `main`
+- **New branches and worktrees must be based on `main`**
+- **Worktrees must be created under `.claude/worktrees/`** (e.g. `git worktree add .claude/worktrees/<name> -b <branch> origin/main`)
 
 ## Local Dev Setup
 


### PR DESCRIPTION
## Summary

- `gae-deploy.yml`: デプロイトリガーをタグベースに変更
  - `deploy-dev`: `develop` → `main` PR 時 → **`main` push 時**に変更
  - `deploy-prod`: `main` push 時 → **`v*` タグ push 時**に変更（任意 revision にタグを打てる = hotfix 対応容易）
  - Slack通知: 前回マージからの差分 → 前回タグからのコミット一覧に変更
- `CLAUDE.md`: Git フローを `main` ベースに更新（`develop` ブランチ廃止）

closes #577 related

## Test Plan

- [ ] `main` に push → `gae-deploy-dev` のみ動作することを確認
- [ ] `v*` タグを push → `gae-deploy-prod` のみ動作し、Slack に前回タグからのコミット一覧が通知されることを確認
- [ ] CLAUDE.md の Git Workflow セクションが新フローを正しく記述していることを確認