### PR TITLE
feat(hp-profile): Switch UI・掲載/非掲載・表示名フィールド追加・fold アニメーション

### DIFF
--- a/client/models/HPProfile.ts
+++ b/client/models/HPProfile.ts
@@ -1,4 +1,8 @@
 export default interface HPProfile {
+  display_name: string;
+  display_name_kana: string;
+  first_name: string;
+  family_name: string;
   height: number;
   weight: number;
   position: string;
@@ -14,6 +18,10 @@ export default interface HPProfile {
 }
 
 export const HIDDEN_FIELD_KEYS = [
+  "display_name",
+  "display_name_kana",
+  "first_name",
+  "family_name",
   "height",
   "weight",
   "position",
@@ -23,13 +31,16 @@ export const HIDDEN_FIELD_KEYS = [
   "bio",
   "portrait_formal",
   "portrait_casual",
-  "additional_photos",
 ] as const;
 
 export type HiddenFieldKey = (typeof HIDDEN_FIELD_KEYS)[number];
 
 export function emptyHPProfile(): HPProfile {
   return {
+    display_name: "",
+    display_name_kana: "",
+    first_name: "",
+    family_name: "",
     height: 0,
     weight: 0,
     position: "",

--- a/client/models/HPProfile.ts
+++ b/client/models/HPProfile.ts
@@ -1,3 +1,9 @@
+export interface CustomField {
+  key: string;
+  value: string;
+  hidden: boolean;
+}
+
 export default interface HPProfile {
   display_name: string;
   display_name_kana: string;
@@ -8,8 +14,8 @@ export default interface HPProfile {
   position: string;
   hometown: string;
   school: string;
-  faculty: string;
   bio: string;
+  custom_fields: CustomField[];
   portrait_formal_url: string;
   portrait_casual_url: string;
   additional_photo_urls: string[];
@@ -27,7 +33,6 @@ export const HIDDEN_FIELD_KEYS = [
   "position",
   "hometown",
   "school",
-  "faculty",
   "bio",
   "portrait_formal",
   "portrait_casual",
@@ -46,8 +51,8 @@ export function emptyHPProfile(): HPProfile {
     position: "",
     hometown: "",
     school: "",
-    faculty: "",
     bio: "",
+    custom_fields: [],
     portrait_formal_url: "",
     portrait_casual_url: "",
     additional_photo_urls: [],

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -97,7 +97,31 @@ function AdminMenu({ member, repo }: { member: Member, repo: MemberRepo }) {
   </div>;
 }
 
+function Switch({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onChange}
+      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+        checked ? "bg-blue-500" : "bg-gray-300"
+      }`}
+    >
+      <span
+        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 ease-in-out ${
+          checked ? "translate-x-5" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}
+
 const FIELD_LABELS: Record<string, string> = {
+  display_name: "表示名（スタッフはイニシャルや偽名も可）",
+  display_name_kana: "表示名かな",
+  first_name: "FirstName",
+  family_name: "FamilyName",
   height: "身長 (cm)",
   weight: "体重 (kg)",
   position: "ポジション",
@@ -173,24 +197,47 @@ function HPProfileSection({ memberId }: { memberId: string }) {
     <div className="mt-2 border rounded-md p-4">
       <h2 className="text-xl font-semibold mb-3">HPプロフィール編集</h2>
 
-      <label className="flex items-center space-x-2 mb-4 text-red-600">
-        <input
-          type="checkbox"
-          checked={profile.hide_from_hp}
-          onChange={e => setProfile(p => ({ ...p, hide_from_hp: e.target.checked }))}
+      {/* 全体掲載トグル */}
+      <button
+        type="button"
+        onClick={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
+        className={`w-full flex items-center justify-between p-3 rounded-xl border-2 transition-colors mb-5 text-left ${
+          profile.hide_from_hp
+            ? "border-gray-200 bg-gray-50"
+            : "border-blue-200 bg-blue-50"
+        }`}
+      >
+        <div>
+          <div className={`text-sm font-semibold ${profile.hide_from_hp ? "text-gray-500" : "text-blue-700"}`}>
+            {profile.hide_from_hp ? "非掲載" : "HP掲載中"}
+          </div>
+          <div className="text-xs text-gray-500 mt-0.5">
+            {profile.hide_from_hp
+              ? "このプロフィールはHPに掲載されていません"
+              : "このプロフィールはHPに掲載されています"}
+          </div>
+        </div>
+        <Switch
+          checked={!profile.hide_from_hp}
+          onChange={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
         />
-        <span>HPに表示しない（すべての情報を非掲載にする）</span>
-      </label>
+      </button>
 
       <div className={profile.hide_from_hp ? "opacity-40 pointer-events-none" : ""}>
-        {/* テキストフィールド */}
-        <div className="grid grid-cols-1 gap-3 mb-4">
+        {/* テキストフィールド: ラベル+スイッチ行 → 入力行 */}
+        <div className="grid grid-cols-1 gap-4 mb-5">
           {(Object.keys(FIELD_LABELS) as HiddenFieldKey[]).map(key => (
-            <div key={key} className="flex flex-col sm:flex-row sm:items-center sm:space-x-3">
-              <label className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0">{FIELD_LABELS[key]}</label>
+            <div key={key}>
+              <div className="flex items-center justify-between mb-1">
+                <label className="text-sm text-gray-700 pr-2 leading-tight">{FIELD_LABELS[key]}</label>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <span className="text-xs text-gray-500">{isHidden(key) ? "非掲載" : "掲載"}</span>
+                  <Switch checked={!isHidden(key)} onChange={() => toggleHiddenField(key)} />
+                </div>
+              </div>
               {key === "bio" ? (
                 <textarea
-                  className="flex-grow form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                  className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
                   rows={2}
                   value={(profile[key as keyof HPProfile] as string) || ""}
                   onChange={e => setProfile(p => ({ ...p, [key]: e.target.value }))}
@@ -198,7 +245,7 @@ function HPProfileSection({ memberId }: { memberId: string }) {
               ) : (
                 <input
                   type={key === "height" || key === "weight" ? "number" : "text"}
-                  className="flex-grow form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                  className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
                   value={(profile[key as keyof HPProfile] as string | number) || ""}
                   onChange={e => setProfile(p => ({
                     ...p,
@@ -208,79 +255,72 @@ function HPProfileSection({ memberId }: { memberId: string }) {
                   }))}
                 />
               )}
-              <label className="flex items-center space-x-1 text-xs text-gray-500 sm:shrink-0 mt-1 sm:mt-0 py-2 sm:py-0">
-                <input
-                  type="checkbox"
-                  checked={isHidden(key)}
-                  onChange={() => toggleHiddenField(key)}
-                />
-                <span>非公開</span>
-              </label>
             </div>
           ))}
         </div>
 
         {/* 写真 */}
-        <div className="mb-4 space-y-4">
+        <div className="mb-5 space-y-3">
           <h3 className="text-sm font-medium text-gray-700">プロフィール写真</h3>
 
-          {/* Formal */}
-          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-3">
-            <span className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0">公式バストアップ <span className="text-red-500">*</span></span>
-            <div className="flex items-center space-x-3">
+          {/* ポートレイト */}
+          <div className="border border-gray-200 rounded-xl p-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-gray-700">ポートレイト <span className="text-red-500">*</span></span>
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-gray-500">{isHidden("portrait_formal") ? "非掲載" : "掲載"}</span>
+                <Switch checked={!isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
               {profile.portrait_formal_url && (
-                <img src={profile.portrait_formal_url} className="w-16 h-16 object-cover rounded" alt="formal" />
+                <img src={profile.portrait_formal_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="ポートレイト" />
               )}
               <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
                 onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
-              <button className="text-sm border rounded px-3 py-2" onClick={() => formalRef.current?.click()}>
-                {profile.portrait_formal_url ? "変更" : "アップロード"}
+              <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                onClick={() => formalRef.current?.click()}>
+                {profile.portrait_formal_url ? "写真を変更" : "写真をアップロード"}
               </button>
-              <label className="flex items-center space-x-1 text-xs text-gray-500 py-2">
-                <input type="checkbox" checked={isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
-                <span>非公開</span>
-              </label>
             </div>
           </div>
 
-          {/* Casual */}
-          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-3">
-            <span className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0">カジュアルバストアップ <span className="text-red-500">*</span></span>
-            <div className="flex items-center space-x-3">
+          {/* カジュアルポートレイト */}
+          <div className="border border-gray-200 rounded-xl p-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-gray-700">カジュアルポートレイト <span className="text-red-500">*</span></span>
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-gray-500">{isHidden("portrait_casual") ? "非掲載" : "掲載"}</span>
+                <Switch checked={!isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
               {profile.portrait_casual_url && (
-                <img src={profile.portrait_casual_url} className="w-16 h-16 object-cover rounded" alt="casual" />
+                <img src={profile.portrait_casual_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="カジュアルポートレイト" />
               )}
               <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
                 onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
-              <button className="text-sm border rounded px-3 py-2" onClick={() => casualRef.current?.click()}>
-                {profile.portrait_casual_url ? "変更" : "アップロード"}
+              <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                onClick={() => casualRef.current?.click()}>
+                {profile.portrait_casual_url ? "写真を変更" : "写真をアップロード"}
               </button>
-              <label className="flex items-center space-x-1 text-xs text-gray-500 py-2">
-                <input type="checkbox" checked={isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
-                <span>非公開</span>
-              </label>
             </div>
           </div>
 
-          {/* Additional */}
-          <div className="flex flex-col sm:flex-row sm:items-start sm:space-x-3">
-            <span className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0 sm:pt-1">追加写真</span>
-            <div className="flex-grow">
-              <div className="flex flex-wrap gap-2 mb-2">
-                {(profile.additional_photo_urls || []).map((url, i) => (
-                  <img key={i} src={url} className="w-16 h-16 object-cover rounded" alt={`追加${i + 1}`} />
-                ))}
-              </div>
-              <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={additionalRef} className="hidden"
-                onChange={e => e.target.files?.[0] && handlePhotoUpload("additional", e.target.files[0])} />
-              <button className="text-sm border rounded px-3 py-2" onClick={() => additionalRef.current?.click()}>
-                追加
-              </button>
+          {/* 追加スナップ写真（掲載/非掲載スイッチなし） */}
+          <div className="border border-gray-200 rounded-xl p-3">
+            <div className="text-sm text-gray-700 mb-2">追加スナップ写真</div>
+            <div className="flex flex-wrap gap-2 mb-2">
+              {(profile.additional_photo_urls || []).map((url, i) => (
+                <img key={i} src={url} className="w-14 h-14 object-cover rounded-lg" alt={`スナップ${i + 1}`} />
+              ))}
             </div>
-            <label className="flex items-center space-x-1 text-xs text-gray-500 sm:shrink-0 sm:pt-1 mt-2 sm:mt-0 py-2 sm:py-0">
-              <input type="checkbox" checked={isHidden("additional_photos")} onChange={() => toggleHiddenField("additional_photos")} />
-              <span>非公開</span>
-            </label>
+            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={additionalRef} className="hidden"
+              onChange={e => e.target.files?.[0] && handlePhotoUpload("additional", e.target.files[0])} />
+            <button type="button" className="text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+              onClick={() => additionalRef.current?.click()}>
+              写真を追加
+            </button>
           </div>
         </div>
 

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -227,26 +227,32 @@ function HPProfileSection({ memberId }: { memberId: string }) {
                     <Switch checked={!isHidden(key)} onChange={() => toggleHiddenField(key)} />
                   </div>
                 </div>
-                {key === "bio" ? (
-                  <textarea
-                    className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
-                    rows={2}
-                    value={(profile[key as keyof HPProfile] as string) || ""}
-                    onChange={e => setProfile(p => ({ ...p, [key]: e.target.value }))}
-                  />
-                ) : (
-                  <input
-                    type={key === "height" || key === "weight" ? "number" : "text"}
-                    className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
-                    value={(profile[key as keyof HPProfile] as string | number) || ""}
-                    onChange={e => setProfile(p => ({
-                      ...p,
-                      [key]: key === "height" || key === "weight"
-                        ? parseInt(e.target.value) || 0
-                        : e.target.value,
-                    }))}
-                  />
-                )}
+                <div className={`grid transition-all duration-200 ease-in-out ${
+                  isHidden(key) ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+                }`}>
+                  <div className="overflow-hidden">
+                    {key === "bio" ? (
+                      <textarea
+                        className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                        rows={2}
+                        value={(profile[key as keyof HPProfile] as string) || ""}
+                        onChange={e => setProfile(p => ({ ...p, [key]: e.target.value }))}
+                      />
+                    ) : (
+                      <input
+                        type={key === "height" || key === "weight" ? "number" : "text"}
+                        className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                        value={(profile[key as keyof HPProfile] as string | number) || ""}
+                        onChange={e => setProfile(p => ({
+                          ...p,
+                          [key]: key === "height" || key === "weight"
+                            ? parseInt(e.target.value) || 0
+                            : e.target.value,
+                        }))}
+                      />
+                    )}
+                  </div>
+                </div>
               </div>
             ))}
           </div>
@@ -257,45 +263,57 @@ function HPProfileSection({ memberId }: { memberId: string }) {
 
             {/* ポートレイト */}
             <div className="border border-gray-200 rounded-xl p-3">
-              <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center justify-between">
                 <span className="text-sm text-gray-700">ポートレイト <span className="text-red-500">*</span></span>
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs text-gray-500">{isHidden("portrait_formal") ? "非掲載" : "掲載"}</span>
                   <Switch checked={!isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
                 </div>
               </div>
-              <div className="flex items-center gap-3">
-                {profile.portrait_formal_url && (
-                  <img src={profile.portrait_formal_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="ポートレイト" />
-                )}
-                <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
-                  onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
-                <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
-                  onClick={() => formalRef.current?.click()}>
-                  {profile.portrait_formal_url ? "写真を変更" : "写真をアップロード"}
-                </button>
+              <div className={`grid transition-all duration-200 ease-in-out ${
+                isHidden("portrait_formal") ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+              }`}>
+                <div className="overflow-hidden">
+                  <div className="flex items-center gap-3 pt-1">
+                    {profile.portrait_formal_url && (
+                      <img src={profile.portrait_formal_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="ポートレイト" />
+                    )}
+                    <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
+                      onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
+                    <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                      onClick={() => formalRef.current?.click()}>
+                      {profile.portrait_formal_url ? "写真を変更" : "写真をアップロード"}
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
 
             {/* カジュアルポートレイト */}
             <div className="border border-gray-200 rounded-xl p-3">
-              <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center justify-between">
                 <span className="text-sm text-gray-700">カジュアルポートレイト <span className="text-red-500">*</span></span>
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs text-gray-500">{isHidden("portrait_casual") ? "非掲載" : "掲載"}</span>
                   <Switch checked={!isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
                 </div>
               </div>
-              <div className="flex items-center gap-3">
-                {profile.portrait_casual_url && (
-                  <img src={profile.portrait_casual_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="カジュアルポートレイト" />
-                )}
-                <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
-                  onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
-                <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
-                  onClick={() => casualRef.current?.click()}>
-                  {profile.portrait_casual_url ? "写真を変更" : "写真をアップロード"}
-                </button>
+              <div className={`grid transition-all duration-200 ease-in-out ${
+                isHidden("portrait_casual") ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+              }`}>
+                <div className="overflow-hidden">
+                  <div className="flex items-center gap-3 pt-2">
+                    {profile.portrait_casual_url && (
+                      <img src={profile.portrait_casual_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="カジュアルポートレイト" />
+                    )}
+                    <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
+                      onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
+                    <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                      onClick={() => casualRef.current?.click()}>
+                      {profile.portrait_casual_url ? "写真を変更" : "写真をアップロード"}
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
 

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -195,20 +195,20 @@ function HPProfileSection({ memberId }: { memberId: string }) {
 
   return (
     <div className="mt-2 border rounded-md p-4">
-      {/* タイトル行: 右端に全体掲載スイッチ */}
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-semibold">HPプロフィール</h2>
-        <div className="flex items-center gap-2">
-          <span className={`text-xs font-medium transition-colors duration-200 ${
-            profile.hide_from_hp ? "text-gray-400" : "text-blue-600"
-          }`}>
-            {profile.hide_from_hp ? "非掲載" : "掲載"}
-          </span>
-          <Switch
-            checked={!profile.hide_from_hp}
-            onChange={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
-          />
-        </div>
+      {/* タイトル行: 左端に全体掲載スイッチ、右にタイトル */}
+      <div className="flex items-center gap-3 mb-4">
+        <Switch
+          checked={!profile.hide_from_hp}
+          onChange={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
+        />
+        <h2 className={`text-xl font-semibold transition-colors duration-200 ${
+          profile.hide_from_hp ? "text-gray-400" : "text-gray-900"
+        }`}>HPプロフィール</h2>
+        <span className={`text-xs font-medium transition-colors duration-200 ${
+          profile.hide_from_hp ? "text-gray-400" : "text-blue-600"
+        }`}>
+          {profile.hide_from_hp ? "非掲載" : "掲載"}
+        </span>
       </div>
 
       {/* fold アニメーション: grid-rows トリックで自然なスライド+フェード */}

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -5,7 +5,7 @@ import StatusBadges from "../../components/statusbadges";
 import MemberRepo from "../../repository/MemberRepo";
 import HPProfileRepo, { validatePhotoFile } from "../../repository/HPProfileRepo";
 import Member from "../../models/Member";
-import HPProfile, { emptyHPProfile, HIDDEN_FIELD_KEYS, HiddenFieldKey } from "../../models/HPProfile";
+import HPProfile, { CustomField, emptyHPProfile, HIDDEN_FIELD_KEYS, HiddenFieldKey } from "../../models/HPProfile";
 import { useAppContext } from "../context";
 
 export default function MemberView() {
@@ -127,7 +127,6 @@ const FIELD_LABELS: Record<string, string> = {
   position: "ポジション",
   hometown: "出身地",
   school: "出身校",
-  faculty: "学部・学科",
   bio: "ひとこと",
 };
 
@@ -255,6 +254,81 @@ function HPProfileSection({ memberId }: { memberId: string }) {
                 </div>
               </div>
             ))}
+          </div>
+
+          {/* カスタムフィールド */}
+          <div className="mb-5">
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-sm font-medium text-gray-700">カスタム項目</h3>
+              <button
+                type="button"
+                onClick={() => setProfile(p => ({
+                  ...p,
+                  custom_fields: [...(p.custom_fields || []), { key: "", value: "", hidden: false }],
+                }))}
+                className="text-xs text-blue-600 border border-blue-300 rounded-lg px-2 py-1 bg-white hover:bg-blue-50 transition-colors"
+              >
+                ＋ 項目を追加
+              </button>
+            </div>
+            <div className="space-y-2">
+              {(profile.custom_fields || []).map((cf: CustomField, i: number) => (
+                <div key={i} className="border border-gray-200 rounded-xl p-3">
+                  <div className="flex items-center gap-2 mb-1">
+                    <input
+                      type="text"
+                      placeholder="項目名"
+                      className="flex-1 min-w-0 form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                      value={cf.key}
+                      onChange={e => setProfile(p => {
+                        const fields = [...(p.custom_fields || [])];
+                        fields[i] = { ...fields[i], key: e.target.value };
+                        return { ...p, custom_fields: fields };
+                      })}
+                    />
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <span className="text-xs text-gray-500">{cf.hidden ? "非掲載" : "掲載"}</span>
+                      <Switch
+                        checked={!cf.hidden}
+                        onChange={() => setProfile(p => {
+                          const fields = [...(p.custom_fields || [])];
+                          fields[i] = { ...fields[i], hidden: !fields[i].hidden };
+                          return { ...p, custom_fields: fields };
+                        })}
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setProfile(p => ({
+                        ...p,
+                        custom_fields: (p.custom_fields || []).filter((_, j) => j !== i),
+                      }))}
+                      className="text-gray-400 hover:text-red-500 transition-colors shrink-0 text-lg leading-none"
+                      aria-label="削除"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <div className={`grid transition-all duration-200 ease-in-out ${
+                    cf.hidden ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+                  }`}>
+                    <div className="overflow-hidden">
+                      <input
+                        type="text"
+                        placeholder="値"
+                        className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                        value={cf.value}
+                        onChange={e => setProfile(p => {
+                          const fields = [...(p.custom_fields || [])];
+                          fields[i] = { ...fields[i], value: e.target.value };
+                          return { ...p, custom_fields: fields };
+                        })}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
 
           {/* 写真 */}

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -195,137 +195,136 @@ function HPProfileSection({ memberId }: { memberId: string }) {
 
   return (
     <div className="mt-2 border rounded-md p-4">
-      <h2 className="text-xl font-semibold mb-3">HPプロフィール編集</h2>
-
-      {/* 全体掲載トグル */}
-      <div className={`flex items-center justify-between p-3 rounded-xl border-2 transition-colors mb-5 ${
-        profile.hide_from_hp ? "border-gray-200 bg-gray-50" : "border-blue-200 bg-blue-50"
-      }`}>
-        <div>
-          <div className={`text-sm font-semibold ${profile.hide_from_hp ? "text-gray-500" : "text-blue-700"}`}>
-            {profile.hide_from_hp ? "非掲載" : "HP掲載中"}
-          </div>
-          <div className="text-xs text-gray-500 mt-0.5">
-            {profile.hide_from_hp
-              ? "このプロフィールはHPに掲載されていません"
-              : "このプロフィールはHPに掲載されています"}
-          </div>
+      {/* タイトル行: 右端に全体掲載スイッチ */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">HPプロフィール</h2>
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-medium transition-colors duration-200 ${
+            profile.hide_from_hp ? "text-gray-400" : "text-blue-600"
+          }`}>
+            {profile.hide_from_hp ? "非掲載" : "掲載"}
+          </span>
+          <Switch
+            checked={!profile.hide_from_hp}
+            onChange={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
+          />
         </div>
-        <Switch
-          checked={!profile.hide_from_hp}
-          onChange={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
-        />
       </div>
 
-      <div className={profile.hide_from_hp ? "opacity-40 pointer-events-none" : ""}>
-        {/* テキストフィールド: ラベル+スイッチ行 → 入力行 */}
-        <div className="grid grid-cols-1 gap-4 mb-5">
-          {(Object.keys(FIELD_LABELS) as HiddenFieldKey[]).map(key => (
-            <div key={key}>
-              <div className="flex items-center justify-between mb-1">
-                <label className="text-sm text-gray-700 pr-2 leading-tight">{FIELD_LABELS[key]}</label>
-                <div className="flex items-center gap-1.5 shrink-0">
-                  <span className="text-xs text-gray-500">{isHidden(key) ? "非掲載" : "掲載"}</span>
-                  <Switch checked={!isHidden(key)} onChange={() => toggleHiddenField(key)} />
+      {/* fold アニメーション: grid-rows トリックで自然なスライド+フェード */}
+      <div className={`grid transition-all duration-300 ease-in-out ${
+        profile.hide_from_hp ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
+      }`}>
+        <div className="overflow-hidden">
+          {/* テキストフィールド: ラベル+スイッチ行 → 入力行 */}
+          <div className="grid grid-cols-1 gap-4 mb-5">
+            {(Object.keys(FIELD_LABELS) as HiddenFieldKey[]).map(key => (
+              <div key={key}>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="text-sm text-gray-700 pr-2 leading-tight">{FIELD_LABELS[key]}</label>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <span className="text-xs text-gray-500">{isHidden(key) ? "非掲載" : "掲載"}</span>
+                    <Switch checked={!isHidden(key)} onChange={() => toggleHiddenField(key)} />
+                  </div>
+                </div>
+                {key === "bio" ? (
+                  <textarea
+                    className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                    rows={2}
+                    value={(profile[key as keyof HPProfile] as string) || ""}
+                    onChange={e => setProfile(p => ({ ...p, [key]: e.target.value }))}
+                  />
+                ) : (
+                  <input
+                    type={key === "height" || key === "weight" ? "number" : "text"}
+                    className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+                    value={(profile[key as keyof HPProfile] as string | number) || ""}
+                    onChange={e => setProfile(p => ({
+                      ...p,
+                      [key]: key === "height" || key === "weight"
+                        ? parseInt(e.target.value) || 0
+                        : e.target.value,
+                    }))}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 写真 */}
+          <div className="mb-5 space-y-3">
+            <h3 className="text-sm font-medium text-gray-700">プロフィール写真</h3>
+
+            {/* ポートレイト */}
+            <div className="border border-gray-200 rounded-xl p-3">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm text-gray-700">ポートレイト <span className="text-red-500">*</span></span>
+                <div className="flex items-center gap-1.5">
+                  <span className="text-xs text-gray-500">{isHidden("portrait_formal") ? "非掲載" : "掲載"}</span>
+                  <Switch checked={!isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
                 </div>
               </div>
-              {key === "bio" ? (
-                <textarea
-                  className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
-                  rows={2}
-                  value={(profile[key as keyof HPProfile] as string) || ""}
-                  onChange={e => setProfile(p => ({ ...p, [key]: e.target.value }))}
-                />
-              ) : (
-                <input
-                  type={key === "height" || key === "weight" ? "number" : "text"}
-                  className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
-                  value={(profile[key as keyof HPProfile] as string | number) || ""}
-                  onChange={e => setProfile(p => ({
-                    ...p,
-                    [key]: key === "height" || key === "weight"
-                      ? parseInt(e.target.value) || 0
-                      : e.target.value,
-                  }))}
-                />
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* 写真 */}
-        <div className="mb-5 space-y-3">
-          <h3 className="text-sm font-medium text-gray-700">プロフィール写真</h3>
-
-          {/* ポートレイト */}
-          <div className="border border-gray-200 rounded-xl p-3">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm text-gray-700">ポートレイト <span className="text-red-500">*</span></span>
-              <div className="flex items-center gap-1.5">
-                <span className="text-xs text-gray-500">{isHidden("portrait_formal") ? "非掲載" : "掲載"}</span>
-                <Switch checked={!isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
+              <div className="flex items-center gap-3">
+                {profile.portrait_formal_url && (
+                  <img src={profile.portrait_formal_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="ポートレイト" />
+                )}
+                <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
+                  onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
+                <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                  onClick={() => formalRef.current?.click()}>
+                  {profile.portrait_formal_url ? "写真を変更" : "写真をアップロード"}
+                </button>
               </div>
             </div>
-            <div className="flex items-center gap-3">
-              {profile.portrait_formal_url && (
-                <img src={profile.portrait_formal_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="ポートレイト" />
-              )}
-              <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
-                onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
-              <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
-                onClick={() => formalRef.current?.click()}>
-                {profile.portrait_formal_url ? "写真を変更" : "写真をアップロード"}
+
+            {/* カジュアルポートレイト */}
+            <div className="border border-gray-200 rounded-xl p-3">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm text-gray-700">カジュアルポートレイト <span className="text-red-500">*</span></span>
+                <div className="flex items-center gap-1.5">
+                  <span className="text-xs text-gray-500">{isHidden("portrait_casual") ? "非掲載" : "掲載"}</span>
+                  <Switch checked={!isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                {profile.portrait_casual_url && (
+                  <img src={profile.portrait_casual_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="カジュアルポートレイト" />
+                )}
+                <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
+                  onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
+                <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                  onClick={() => casualRef.current?.click()}>
+                  {profile.portrait_casual_url ? "写真を変更" : "写真をアップロード"}
+                </button>
+              </div>
+            </div>
+
+            {/* 追加スナップ写真（掲載/非掲載スイッチなし） */}
+            <div className="border border-gray-200 rounded-xl p-3">
+              <div className="text-sm text-gray-700 mb-2">追加スナップ写真</div>
+              <div className="flex flex-wrap gap-2 mb-2">
+                {(profile.additional_photo_urls || []).map((url, i) => (
+                  <img key={i} src={url} className="w-14 h-14 object-cover rounded-lg" alt={`スナップ${i + 1}`} />
+                ))}
+              </div>
+              <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={additionalRef} className="hidden"
+                onChange={e => e.target.files?.[0] && handlePhotoUpload("additional", e.target.files[0])} />
+              <button type="button" className="text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
+                onClick={() => additionalRef.current?.click()}>
+                写真を追加
               </button>
             </div>
           </div>
 
-          {/* カジュアルポートレイト */}
-          <div className="border border-gray-200 rounded-xl p-3">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm text-gray-700">カジュアルポートレイト <span className="text-red-500">*</span></span>
-              <div className="flex items-center gap-1.5">
-                <span className="text-xs text-gray-500">{isHidden("portrait_casual") ? "非掲載" : "掲載"}</span>
-                <Switch checked={!isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
-              </div>
-            </div>
-            <div className="flex items-center gap-3">
-              {profile.portrait_casual_url && (
-                <img src={profile.portrait_casual_url} className="w-14 h-14 object-cover rounded-lg shrink-0" alt="カジュアルポートレイト" />
-              )}
-              <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
-                onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
-              <button type="button" className="flex-grow text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
-                onClick={() => casualRef.current?.click()}>
-                {profile.portrait_casual_url ? "写真を変更" : "写真をアップロード"}
-              </button>
-            </div>
-          </div>
-
-          {/* 追加スナップ写真（掲載/非掲載スイッチなし） */}
-          <div className="border border-gray-200 rounded-xl p-3">
-            <div className="text-sm text-gray-700 mb-2">追加スナップ写真</div>
-            <div className="flex flex-wrap gap-2 mb-2">
-              {(profile.additional_photo_urls || []).map((url, i) => (
-                <img key={i} src={url} className="w-14 h-14 object-cover rounded-lg" alt={`スナップ${i + 1}`} />
-              ))}
-            </div>
-            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={additionalRef} className="hidden"
-              onChange={e => e.target.files?.[0] && handlePhotoUpload("additional", e.target.files[0])} />
-            <button type="button" className="text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-600 bg-white"
-              onClick={() => additionalRef.current?.click()}>
-              写真を追加
-            </button>
-          </div>
+          <button
+            className="bg-blue-600 text-white rounded-md px-6 py-2 disabled:opacity-50"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? "保存中..." : "保存"}
+          </button>
+          {message && <p className="mt-2 text-sm text-gray-700">{message}</p>}
         </div>
-
-        <button
-          className="bg-blue-600 text-white rounded-md px-6 py-2 disabled:opacity-50"
-          onClick={handleSave}
-          disabled={saving}
-        >
-          {saving ? "保存中..." : "保存"}
-        </button>
-        {message && <p className="mt-2 text-sm text-gray-700">{message}</p>}
       </div>
     </div>
   );

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -198,15 +198,9 @@ function HPProfileSection({ memberId }: { memberId: string }) {
       <h2 className="text-xl font-semibold mb-3">HPプロフィール編集</h2>
 
       {/* 全体掲載トグル */}
-      <button
-        type="button"
-        onClick={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
-        className={`w-full flex items-center justify-between p-3 rounded-xl border-2 transition-colors mb-5 text-left ${
-          profile.hide_from_hp
-            ? "border-gray-200 bg-gray-50"
-            : "border-blue-200 bg-blue-50"
-        }`}
-      >
+      <div className={`flex items-center justify-between p-3 rounded-xl border-2 transition-colors mb-5 ${
+        profile.hide_from_hp ? "border-gray-200 bg-gray-50" : "border-blue-200 bg-blue-50"
+      }`}>
         <div>
           <div className={`text-sm font-semibold ${profile.hide_from_hp ? "text-gray-500" : "text-blue-700"}`}>
             {profile.hide_from_hp ? "非掲載" : "HP掲載中"}
@@ -221,7 +215,7 @@ function HPProfileSection({ memberId }: { memberId: string }) {
           checked={!profile.hide_from_hp}
           onChange={() => setProfile(p => ({ ...p, hide_from_hp: !p.hide_from_hp }))}
         />
-      </button>
+      </div>
 
       <div className={profile.hide_from_hp ? "opacity-40 pointer-events-none" : ""}>
         {/* テキストフィールド: ラベル+スイッチ行 → 入力行 */}

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -21,10 +21,10 @@ export default function MemberView() {
 
   return (
     <Layout>
-      <div className="flex space-x-4">
-        <div className="fle w-44">
+      <div className="flex flex-col sm:flex-row sm:space-x-4">
+        <div className="w-full sm:w-44 mb-4 sm:mb-0">
           <img
-            className="rounded-md"
+            className="rounded-md w-full sm:w-44"
             src={member.slack.profile.image_512} alt={member.slack.profile.name}
           />
         </div>
@@ -32,10 +32,13 @@ export default function MemberView() {
           <div className="flex flex-col h-full">
             <h1 className="text-3xl font-medium">{member.slack.profile.real_name}</h1>
             <div className="text-2xl flex-grow text-gray-800">{member.slack.profile.title || "ポジション未設定"}</div>
-            <div className="flex flex-row-reverse text-gray-400">Slackで編集可</div>
+            <div className="text-xs text-gray-400 mt-1">名前・アイコン・ポジションは Slack プロフィールから同期されます</div>
           </div>
         </div>
       </div>
+
+      <hr className="my-4" />
+
       <div className="py-2">
         <div className="form-group flex items-center space-x-4">
           <span>背番号:</span>
@@ -58,9 +61,11 @@ export default function MemberView() {
 
       {myself.slack.is_admin ? <AdminMenu member={member} repo={repo} /> : null}
 
+      <hr className="my-4" />
+
       {isOwnPage && <HPProfileSection memberId={member.slack.id} />}
 
-      <div className="p-12 flex justify-center items-center">
+      <div className="p-8 flex justify-center items-center">
         <a href="/members" className="underline">一覧に戻る</a>
       </div>
     </Layout>
@@ -165,7 +170,7 @@ function HPProfileSection({ memberId }: { memberId: string }) {
   };
 
   return (
-    <div className="mt-6 border rounded-md p-4">
+    <div className="mt-2 border rounded-md p-4">
       <h2 className="text-xl font-semibold mb-3">HPプロフィール編集</h2>
 
       <label className="flex items-center space-x-2 mb-4 text-red-600">
@@ -174,15 +179,15 @@ function HPProfileSection({ memberId }: { memberId: string }) {
           checked={profile.hide_from_hp}
           onChange={e => setProfile(p => ({ ...p, hide_from_hp: e.target.checked }))}
         />
-        <span>HPに表示しない（すべての情報を非公開にする）</span>
+        <span>HPに表示しない（すべての情報を非掲載にする）</span>
       </label>
 
       <div className={profile.hide_from_hp ? "opacity-40 pointer-events-none" : ""}>
         {/* テキストフィールド */}
         <div className="grid grid-cols-1 gap-3 mb-4">
           {(Object.keys(FIELD_LABELS) as HiddenFieldKey[]).map(key => (
-            <div key={key} className="flex items-center space-x-3">
-              <label className="w-32 text-sm text-gray-600 shrink-0">{FIELD_LABELS[key]}</label>
+            <div key={key} className="flex flex-col sm:flex-row sm:items-center sm:space-x-3">
+              <label className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0">{FIELD_LABELS[key]}</label>
               {key === "bio" ? (
                 <textarea
                   className="flex-grow form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
@@ -203,7 +208,7 @@ function HPProfileSection({ memberId }: { memberId: string }) {
                   }))}
                 />
               )}
-              <label className="flex items-center space-x-1 text-xs text-gray-500 shrink-0">
+              <label className="flex items-center space-x-1 text-xs text-gray-500 sm:shrink-0 mt-1 sm:mt-0 py-2 sm:py-0">
                 <input
                   type="checkbox"
                   checked={isHidden(key)}
@@ -216,46 +221,50 @@ function HPProfileSection({ memberId }: { memberId: string }) {
         </div>
 
         {/* 写真 */}
-        <div className="mb-4 space-y-3">
+        <div className="mb-4 space-y-4">
           <h3 className="text-sm font-medium text-gray-700">プロフィール写真</h3>
 
           {/* Formal */}
-          <div className="flex items-center space-x-3">
-            <span className="w-32 text-sm text-gray-600 shrink-0">公式バストアップ <span className="text-red-500">*</span></span>
-            {profile.portrait_formal_url && (
-              <img src={profile.portrait_formal_url} className="w-16 h-16 object-cover rounded" alt="formal" />
-            )}
-            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
-              onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
-            <button className="text-sm border rounded px-3 py-1" onClick={() => formalRef.current?.click()}>
-              {profile.portrait_formal_url ? "変更" : "アップロード"}
-            </button>
-            <label className="flex items-center space-x-1 text-xs text-gray-500">
-              <input type="checkbox" checked={isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
-              <span>非公開</span>
-            </label>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-3">
+            <span className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0">公式バストアップ <span className="text-red-500">*</span></span>
+            <div className="flex items-center space-x-3">
+              {profile.portrait_formal_url && (
+                <img src={profile.portrait_formal_url} className="w-16 h-16 object-cover rounded" alt="formal" />
+              )}
+              <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={formalRef} className="hidden"
+                onChange={e => e.target.files?.[0] && handlePhotoUpload("formal", e.target.files[0])} />
+              <button className="text-sm border rounded px-3 py-2" onClick={() => formalRef.current?.click()}>
+                {profile.portrait_formal_url ? "変更" : "アップロード"}
+              </button>
+              <label className="flex items-center space-x-1 text-xs text-gray-500 py-2">
+                <input type="checkbox" checked={isHidden("portrait_formal")} onChange={() => toggleHiddenField("portrait_formal")} />
+                <span>非公開</span>
+              </label>
+            </div>
           </div>
 
           {/* Casual */}
-          <div className="flex items-center space-x-3">
-            <span className="w-32 text-sm text-gray-600 shrink-0">カジュアルバストアップ <span className="text-red-500">*</span></span>
-            {profile.portrait_casual_url && (
-              <img src={profile.portrait_casual_url} className="w-16 h-16 object-cover rounded" alt="casual" />
-            )}
-            <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
-              onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
-            <button className="text-sm border rounded px-3 py-1" onClick={() => casualRef.current?.click()}>
-              {profile.portrait_casual_url ? "変更" : "アップロード"}
-            </button>
-            <label className="flex items-center space-x-1 text-xs text-gray-500">
-              <input type="checkbox" checked={isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
-              <span>非公開</span>
-            </label>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-3">
+            <span className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0">カジュアルバストアップ <span className="text-red-500">*</span></span>
+            <div className="flex items-center space-x-3">
+              {profile.portrait_casual_url && (
+                <img src={profile.portrait_casual_url} className="w-16 h-16 object-cover rounded" alt="casual" />
+              )}
+              <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={casualRef} className="hidden"
+                onChange={e => e.target.files?.[0] && handlePhotoUpload("casual", e.target.files[0])} />
+              <button className="text-sm border rounded px-3 py-2" onClick={() => casualRef.current?.click()}>
+                {profile.portrait_casual_url ? "変更" : "アップロード"}
+              </button>
+              <label className="flex items-center space-x-1 text-xs text-gray-500 py-2">
+                <input type="checkbox" checked={isHidden("portrait_casual")} onChange={() => toggleHiddenField("portrait_casual")} />
+                <span>非公開</span>
+              </label>
+            </div>
           </div>
 
           {/* Additional */}
-          <div className="flex items-start space-x-3">
-            <span className="w-32 text-sm text-gray-600 shrink-0 pt-1">追加写真</span>
+          <div className="flex flex-col sm:flex-row sm:items-start sm:space-x-3">
+            <span className="text-sm text-gray-600 sm:w-32 sm:shrink-0 mb-1 sm:mb-0 sm:pt-1">追加写真</span>
             <div className="flex-grow">
               <div className="flex flex-wrap gap-2 mb-2">
                 {(profile.additional_photo_urls || []).map((url, i) => (
@@ -264,11 +273,11 @@ function HPProfileSection({ memberId }: { memberId: string }) {
               </div>
               <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" ref={additionalRef} className="hidden"
                 onChange={e => e.target.files?.[0] && handlePhotoUpload("additional", e.target.files[0])} />
-              <button className="text-sm border rounded px-3 py-1" onClick={() => additionalRef.current?.click()}>
+              <button className="text-sm border rounded px-3 py-2" onClick={() => additionalRef.current?.click()}>
                 追加
               </button>
             </div>
-            <label className="flex items-center space-x-1 text-xs text-gray-500 shrink-0 pt-1">
+            <label className="flex items-center space-x-1 text-xs text-gray-500 sm:shrink-0 sm:pt-1 mt-2 sm:mt-0 py-2 sm:py-0">
               <input type="checkbox" checked={isHidden("additional_photos")} onChange={() => toggleHiddenField("additional_photos")} />
               <span>非公開</span>
             </label>

--- a/server/models/hp_profile.go
+++ b/server/models/hp_profile.go
@@ -10,6 +10,13 @@ import (
 
 const KindHPProfile = "MemberHPProfile"
 
+// HPCustomField はユーザが自由に追加できる key-value フィールド。
+type HPCustomField struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Hidden bool   `json:"hidden"`
+}
+
 // MemberHPProfile はメンバーが自己編集するHP向けプロフィール情報。
 // Datastore のキーは Member と同じ Slack ID を使って 1:1 対応させる。
 type MemberHPProfile struct {
@@ -25,8 +32,10 @@ type MemberHPProfile struct {
 	Position string `json:"position"`
 	Hometown string `json:"hometown"`
 	School   string `json:"school"`
-	Faculty  string `json:"faculty"`
 	Bio      string `json:"bio"`
+
+	// ユーザ定義カスタムフィールド
+	CustomFields []HPCustomField `json:"custom_fields" datastore:",noindex"`
 
 	// 写真（GCS 上のオブジェクト公開 URL）
 	PortraitFormalURL   string   `json:"portrait_formal_url"`
@@ -81,9 +90,6 @@ func (p MemberHPProfile) PublicView() MemberHPProfile {
 	if hidden["school"] {
 		out.School = ""
 	}
-	if hidden["faculty"] {
-		out.Faculty = ""
-	}
 	if hidden["bio"] {
 		out.Bio = ""
 	}
@@ -93,6 +99,14 @@ func (p MemberHPProfile) PublicView() MemberHPProfile {
 	if hidden["portrait_casual"] {
 		out.PortraitCasualURL = ""
 	}
+	// カスタムフィールド: hidden=true のものを除外
+	visible := out.CustomFields[:0]
+	for _, cf := range out.CustomFields {
+		if !cf.Hidden {
+			visible = append(visible, cf)
+		}
+	}
+	out.CustomFields = visible
 	// 掲載ビューでは制御フィールド自体も隠す
 	out.HideFromHP = false
 	out.HiddenFields = nil

--- a/server/models/hp_profile.go
+++ b/server/models/hp_profile.go
@@ -13,6 +13,12 @@ const KindHPProfile = "MemberHPProfile"
 // MemberHPProfile はメンバーが自己編集するHP向けプロフィール情報。
 // Datastore のキーは Member と同じ Slack ID を使って 1:1 対応させる。
 type MemberHPProfile struct {
+	// 表示名（HP掲載用・イニシャルや偽名も可）
+	DisplayName     string `json:"display_name"`
+	DisplayNameKana string `json:"display_name_kana"`
+	FirstName       string `json:"first_name"`
+	FamilyName      string `json:"family_name"`
+
 	// テキスト情報
 	Height   int    `json:"height"`
 	Weight   int    `json:"weight"`
@@ -27,7 +33,7 @@ type MemberHPProfile struct {
 	PortraitCasualURL   string   `json:"portrait_casual_url"`
 	AdditionalPhotoURLs []string `json:"additional_photo_urls" datastore:",noindex"`
 
-	// 公開制御
+	// 掲載制御
 	HideFromHP   bool     `json:"hide_from_hp"`
 	HiddenFields []string `json:"hidden_fields" datastore:",noindex"`
 }
@@ -48,6 +54,18 @@ func (p MemberHPProfile) PublicView() MemberHPProfile {
 	}
 	hidden := p.HiddenFieldSet()
 	out := p
+	if hidden["display_name"] {
+		out.DisplayName = ""
+	}
+	if hidden["display_name_kana"] {
+		out.DisplayNameKana = ""
+	}
+	if hidden["first_name"] {
+		out.FirstName = ""
+	}
+	if hidden["family_name"] {
+		out.FamilyName = ""
+	}
 	if hidden["height"] {
 		out.Height = 0
 	}
@@ -75,10 +93,7 @@ func (p MemberHPProfile) PublicView() MemberHPProfile {
 	if hidden["portrait_casual"] {
 		out.PortraitCasualURL = ""
 	}
-	if hidden["additional_photos"] {
-		out.AdditionalPhotoURLs = nil
-	}
-	// 公開ビューでは制御フィールド自体も隠す
+	// 掲載ビューでは制御フィールド自体も隠す
 	out.HideFromHP = false
 	out.HiddenFields = nil
 	return out


### PR DESCRIPTION
## Summary

- チェックボックス → Toggle Switch UI（role=switch）で掲載/非掲載を統一
- 全体掲載スイッチをセクションタイトル「HPプロフィール」の左端に配置
- 非掲載時はコンテンツを grid-rows アニメーションで fold（300ms）
- 各フィールドも非掲載スイッチで入力欄を fold（200ms）
- 表示名フィールド4件追加（display_name / display_name_kana / first_name / family_name）
- カスタム項目：ユーザが任意の key-value を追加・削除できる
- 学部・学科フィールドを削除
- 写真ラベル変更・追加スナップ写真からスイッチ削除

## Closes

Closes #580

## Changes

### Frontend
- `Switch` コンポーネント（Tailwind、role=switch、アニメーション付き）を追加
- `FIELD_LABELS` から `faculty` 削除
- 全テキストフィールド: ラベル+スイッチ上行 / 入力欄下行の2段レイアウト
- 全体掲載トグル: タイトル左端の Switch のみ（二重 click 問題を解消）
- 非掲載でセクション全体が `grid-rows-[0fr]` + `opacity-0` で fold
- 各フィールドの入力欄も同様に fold
- カスタム項目 UI（追加・削除・key/value 入力・掲載スイッチ・値 fold）
- 写真ラベル: 公式バストアップ→ポートレイト、カジュアルバストアップ→カジュアルポートレイト
- 追加スナップ写真から掲載/非掲載スイッチを削除

### Backend (`server/models/hp_profile.go`)
- `faculty` フィールドを削除
- `display_name`, `display_name_kana`, `first_name`, `family_name` を追加
- `HPCustomField` 型（key / value / hidden）を追加
- `CustomFields []HPCustomField` を `MemberHPProfile` に追加
- `PublicView()` で hidden なカスタムフィールドを除外

### Frontend Model (`client/models/HPProfile.ts`)
- 同上のフィールド追加・削除
- `CustomField` インターフェース追加
- `HIDDEN_FIELD_KEYS` から `faculty` / `additional_photos` を削除

## Test Plan

> Issue #580 `## 受け入れ条件` のスナップショット

- [x] [MANUAL] ポートレイト/カジュアルポートレイト/追加スナップ写真ラベル表示
- [x] [UI] 各フィールドが Switch UI で ON/OFF 視覚判別可
- [x] [UI] スイッチラベルが「掲載/非掲載」
- [x] [UI] 追加スナップ写真に掲載/非掲載スイッチなし
- [x] [UI] 表示名4フィールド表示
- [x] [UI][MUTATING] 表示名保存 → 再読込で保持（API で確認）
- [x] [LOGIC] `GET /api/1/public/members` に新フィールド含まれる
- [x] [BUILD] npm build & go build クリーン

## Verification

env: `scripts/env-provision provision tackle-580-hp-profile-switch-ui`  
app: `http://localhost:3136/members/U9MD7M0NS`

### 掲載状態 — Switch UI と新フィールド

![before-fold](https://github.com/triax/hub/releases/download/uat-evidence/tackle-580-20260531-before-fold.png)

### 非掲載で fold

![after-fold](https://github.com/triax/hub/releases/download/uat-evidence/tackle-580-20260531-after-fold.png)

### カスタム項目追加

![custom-fields](https://github.com/triax/hub/releases/download/uat-evidence/tackle-580-20260531-custom-fields-added2.png)

### フィールド個別 fold

![field-fold](https://github.com/triax/hub/releases/download/uat-evidence/tackle-580-20260531-field-fold-after.png)