### PR TITLE
feat(members): モバイルナビ改善・背番号をHPプロフィールへ統合

### DIFF
--- a/client/components/layout.tsx
+++ b/client/components/layout.tsx
@@ -198,7 +198,7 @@ export default function Layout({ children }: LayoutProps) {
                 ))}
               </div>
               <div className="pt-4 pb-3 border-t border-gray-700">
-                <div className="flex items-center px-5">
+                <a href={`/members/${myself.slack.id}`} className="flex items-center px-5 hover:bg-gray-700 rounded-md py-2 transition-colors">
                   <div className="flex-shrink-0">
                     {myIcon ? <img
                       className="h-10 w-10 rounded-full"
@@ -208,17 +208,8 @@ export default function Layout({ children }: LayoutProps) {
                   </div>
                   <div className="ml-3">
                     <div className="text-base font-medium leading-none text-white">{myself.slack.profile.real_name}</div>
-                    <div className="text-sm font-medium leading-none text-gray-400">tom@example.com</div>
                   </div>
-
-                  <button
-                    type="button"
-                    className="ml-auto bg-gray-800 flex-shrink-0 p-1 rounded-full text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
-                  >
-                    <span className="sr-only">View Notifications</span>
-                    <BellIcon className="h-6 w-6" aria-hidden="true" />
-                  </button>
-                </div>
+                </a>
                 <div className="mt-3 px-2 space-y-1">
                   <form
                     method="POST" action="/logout"

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -13,7 +13,6 @@ export default function MemberView() {
   const repo = useMemo(() => new MemberRepo(), []);
   const { id } = useParams({ strict: false });
   const [member, setMember] = useState<Member>(null);
-  const [num, setNumberInput] = useState<number>(null);
   useEffect(() => { if (id) repo.get(id).then(setMember); }, [id, repo]);
   if (!member) return <></>;
 
@@ -40,22 +39,6 @@ export default function MemberView() {
       <hr className="my-4" />
 
       <div className="py-2">
-        <div className="form-group flex items-center space-x-4">
-          <span>背番号:</span>
-          <input type="number"
-            defaultValue={member.number || num}
-            onChange={ev => setNumberInput(parseInt(ev.target.value))}
-            className="flex-grow form-input border-transparent bg-gray-100 rounded-md"
-            placeholder="0~99を選択"
-            min="0" max="99" step="1"
-          />
-          <button
-            role="button" className="border rounded-md px-4 py-2 cursor-pointer"
-            onClick={() => repo.update(member.slack.id, { number: num })}
-          >設定</button>
-        </div>
-      </div>
-      <div className="py-2">
         <div className="flex space-x-2"><StatusBadges member={member} size="text-lg px-4 py-1" /></div>
       </div>
 
@@ -63,7 +46,13 @@ export default function MemberView() {
 
       <hr className="my-4" />
 
-      {isOwnPage && <HPProfileSection memberId={member.slack.id} />}
+      {isOwnPage && (
+        <HPProfileSection
+          memberId={member.slack.id}
+          initialNumber={member.number ?? null}
+          onSaveNumber={(n) => repo.update(member.slack.id, { number: n })}
+        />
+      )}
 
       <div className="p-8 flex justify-center items-center">
         <a href="/members" className="underline">一覧に戻る</a>
@@ -130,9 +119,18 @@ const FIELD_LABELS: Record<string, string> = {
   bio: "ひとこと",
 };
 
-function HPProfileSection({ memberId }: { memberId: string }) {
+function HPProfileSection({
+  memberId,
+  initialNumber,
+  onSaveNumber,
+}: {
+  memberId: string;
+  initialNumber: number | null;
+  onSaveNumber?: (n: number | null) => Promise<void>;
+}) {
   const repo = useMemo(() => new HPProfileRepo(), []);
   const [profile, setProfile] = useState<HPProfile>(emptyHPProfile());
+  const [jerseyNumber, setJerseyNumber] = useState<number | null>(initialNumber ?? null);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
   const formalRef = useRef<HTMLInputElement>(null);
@@ -163,6 +161,9 @@ function HPProfileSection({ memberId }: { memberId: string }) {
     try {
       const saved = await repo.update(memberId, profile);
       setProfile(saved);
+      if (onSaveNumber) {
+        await onSaveNumber(jerseyNumber);
+      }
       setMessage("保存しました");
     } catch (e) {
       setMessage("保存に失敗しました: " + (e as Error).message);
@@ -215,6 +216,21 @@ function HPProfileSection({ memberId }: { memberId: string }) {
         profile.hide_from_hp ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
       }`}>
         <div className="overflow-hidden">
+          {/* 背番号 */}
+          <div className="mb-5">
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-sm text-gray-700">背番号</label>
+            </div>
+            <input
+              type="number"
+              className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
+              value={jerseyNumber ?? ""}
+              onChange={e => setJerseyNumber(e.target.value === "" ? null : parseInt(e.target.value))}
+              placeholder="0〜99"
+              min="0" max="99" step="1"
+            />
+          </div>
+
           {/* テキストフィールド: ラベル+スイッチ行 → 入力行 */}
           <div className="grid grid-cols-1 gap-4 mb-5">
             {(Object.keys(FIELD_LABELS) as HiddenFieldKey[]).map(key => (

--- a/client/src/pages/members.$id.tsx
+++ b/client/src/pages/members.$id.tsx
@@ -50,6 +50,7 @@ export default function MemberView() {
         <HPProfileSection
           memberId={member.slack.id}
           initialNumber={member.number ?? null}
+          slackTitle={member.slack.profile.title || ""}
           onSaveNumber={(n) => repo.update(member.slack.id, { number: n })}
         />
       )}
@@ -122,15 +123,18 @@ const FIELD_LABELS: Record<string, string> = {
 function HPProfileSection({
   memberId,
   initialNumber,
+  slackTitle,
   onSaveNumber,
 }: {
   memberId: string;
   initialNumber: number | null;
+  slackTitle: string;
   onSaveNumber?: (n: number | null) => Promise<void>;
 }) {
   const repo = useMemo(() => new HPProfileRepo(), []);
   const [profile, setProfile] = useState<HPProfile>(emptyHPProfile());
   const [jerseyNumber, setJerseyNumber] = useState<number | null>(initialNumber ?? null);
+  const [showPositionHint, setShowPositionHint] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
   const formalRef = useRef<HTMLInputElement>(null);
@@ -159,7 +163,8 @@ function HPProfileSection({
     setSaving(true);
     setMessage("");
     try {
-      const saved = await repo.update(memberId, profile);
+      const profileToSave = slackTitle ? { ...profile, position: slackTitle } : profile;
+      const saved = await repo.update(memberId, profileToSave);
       setProfile(saved);
       if (onSaveNumber) {
         await onSaveNumber(jerseyNumber);
@@ -246,7 +251,22 @@ function HPProfileSection({
                   isHidden(key) ? "grid-rows-[0fr] opacity-0" : "grid-rows-[1fr] opacity-100"
                 }`}>
                   <div className="overflow-hidden">
-                    {key === "bio" ? (
+                    {key === "position" ? (
+                      <>
+                        <div className="flex items-center gap-2 bg-gray-50 border border-gray-200 rounded-md text-sm p-2 text-gray-500 min-h-[38px]">
+                          <span className="flex-1">{slackTitle || "（未設定）"}</span>
+                          <button
+                            type="button"
+                            onClick={() => setShowPositionHint(p => !p)}
+                            className="w-5 h-5 rounded-full bg-gray-200 text-gray-500 text-xs flex items-center justify-center hover:bg-gray-300 shrink-0"
+                            aria-label="説明"
+                          >?</button>
+                        </div>
+                        {showPositionHint && (
+                          <p className="mt-1 text-xs text-blue-500">Slackプロフィールの Title / 役職 欄を更新してください</p>
+                        )}
+                      </>
+                    ) : key === "bio" ? (
                       <textarea
                         className="w-full form-input border border-gray-200 bg-gray-50 rounded-md text-sm p-2"
                         rows={2}


### PR DESCRIPTION
## Summary

- ハンバーガーメニューのアイコン＋名前エリアをタップで `/members/{自分のID}` へ遷移
- ハードコードされていた `tom@example.com` を削除
- 背番号入力を独立セクションから HPプロフィールセクションへ移動し、「保存」ボタンで HP プロフィールと同時保存
- ポジション欄を Slack title 連動の読み取り専用表示に変更、`?` ボタンで編集案内を表示

## Changes

- `client/components/layout.tsx`: モバイルメニューのユーザーエリアを `<a>` で包みプロフィールページへリンク、`tom@example.com` 削除
- `client/src/pages/members.$id.tsx`:
  - 背番号の独立セクション削除、`HPProfileSection` に `initialNumber` / `onSaveNumber` props 追加、fold エリア先頭に背番号フィールド配置、`0` を falsy 扱いしないよう `??` で初期化
  - ポジション入力を read-only 表示に変更（値は `member.slack.profile.title` を使用）
  - `?` ボタンタップで「Slackプロフィールの Title / 役職 欄を更新してください」を表示
  - 保存時に `profile.position` を Slack title で自動同期

## Test Plan

- [ ] [UI] モバイル幅でハンバーガーを開き、アイコン＋名前タップ → `/members/{id}` へ遷移する
- [ ] [UI] ハンバーガーメニューに `tom@example.com` が表示されない
- [ ] [UI] HPプロフィールセクション内に「背番号」入力欄がある
- [ ] [UI] 背番号に `0` を入力して保存 → 正しく `0` が保存される（空欄・null にならない）
- [ ] [UI] 背番号と HP プロフィールが「保存」ボタン 1 回で同時保存される
- [ ] [UI] ポジション欄が編集不可（read-only）で Slack title の値が表示される
- [ ] [UI] ポジション欄の `?` ボタンをタップ → 「Slackプロフィールの Title / 役職 欄を更新してください」が表示される