### PR TITLE
fix(datastore): Application 複合インデックス未定義を修正 (#588)

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,11 @@
 indexes:
 
+- kind: Application
+  properties:
+  - name: Type
+  - name: CreatedAt
+    direction: desc
+
 - kind: Custody
   ancestor: yes
   properties:


### PR DESCRIPTION
## Summary

- `index.yaml` に `Application` 種別の複合インデックス（`Type` + `CreatedAt desc`）を追加
- これにより `/applications` ページの `FailedPrecondition: no matching index found` エラーを解消

## Closes

Closes #588

## Changes

- `index.yaml`: `Application` の複合インデックスエントリを追加（`Type` 昇順 + `CreatedAt` 降順）

## Test Plan

> 注: このセクションは PR 作成時点での Issue #588 `## 受け入れ条件` のスナップショット。

### 検証方針

- 対象画面: 入部申請管理 `/applications`
- URL:
  - local: http://localhost:8080/applications （要 Datastore 接続設定）
  - prod: https://hub.triax.football/applications
- 認証: Hub 管理者権限でログイン済みであること
- 前提データ: Datastore に `Application` エンティティが 1 件以上存在すること（またはエラーが消えることを確認）

### 検証項目

- [ ] [UI] https://hub.triax.football/applications を開いたとき、赤いエラーボックスが表示されないこと
- [ ] [UI] 「未対応」タブ・「すべて」タブを切り替えても申請一覧が正常にロードされること（件数 0 の場合は「表示する申請はありません。」が表示されること）
- [x] [BUILD] `go build -v ./...` がエラーなく完了すること

## Verification

- [BUILD] `go build -v ./...` → 成功 ✅
- [UI] prod での確認はインデックスビルド完了後（デプロイ後数分〜数十分）に実施