### PR TITLE
feat(application): 入部申請送信時に Slack 通知 (#593)

### DIFF
--- a/server/api/application.go
+++ b/server/api/application.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/otiai10/marmoset"
+	"github.com/slack-go/slack"
 	"github.com/triax/hub/server/filters"
 	"github.com/triax/hub/server/models"
 )
@@ -73,6 +76,16 @@ func CreateApplication(w http.ResponseWriter, req *http.Request) {
 	if err := models.PutApplication(req.Context(), id, app); err != nil {
 		render.JSON(http.StatusInternalServerError, marmoset.P{"error": err.Error()})
 		return
+	}
+
+	if input.Type == "onboarding" {
+		go func() {
+			api := slack.New(os.Getenv("SLACK_BOT_USER_OAUTH_TOKEN"))
+			msg := fmt.Sprintf("<!channel> 新しい入部申請が届きました。\nhttps://hub.triax.football/applications")
+			if _, _, err := api.PostMessage("C06SZGR7L1W", slack.MsgOptionText(msg, false)); err != nil {
+				log.Printf("[ERROR] 9010 Slack notification for new application: %v", err)
+			}
+		}()
 	}
 
 	type response struct {

--- a/server/api/application.go
+++ b/server/api/application.go
@@ -18,6 +18,8 @@ import (
 	"github.com/triax/hub/server/models"
 )
 
+const slackChannelApplications = "C06SZGR7L1W" // #入部退部者処理
+
 func isApplicationAdmin(ctx context.Context, slackID string) (bool, error) {
 	client, err := datastore.NewClient(ctx, os.Getenv("GOOGLE_CLOUD_PROJECT"))
 	if err != nil {
@@ -82,7 +84,7 @@ func CreateApplication(w http.ResponseWriter, req *http.Request) {
 		go func() {
 			api := slack.New(os.Getenv("SLACK_BOT_USER_OAUTH_TOKEN"))
 			msg := fmt.Sprintf("<!channel> 新しい入部申請が届きました。\nhttps://hub.triax.football/applications")
-			if _, _, err := api.PostMessage("C06SZGR7L1W", slack.MsgOptionText(msg, false)); err != nil {
+			if _, _, err := api.PostMessage(slackChannelApplications, slack.MsgOptionText(msg, false)); err != nil {
 				log.Printf("[ERROR] 9010 Slack notification for new application: %v", err)
 			}
 		}()

--- a/server/api/application.go
+++ b/server/api/application.go
@@ -20,6 +20,18 @@ import (
 
 const slackChannelApplications = "C06SZGR7L1W" // #入部退部者処理
 
+// isAllowedOrigin はブラウザ経由の正規リクエストかどうかを Origin ヘッダーで判定する。
+// 非認証エンドポイントへの Slack 通知増幅を防ぐためのガード。
+func isAllowedOrigin(origin string) bool {
+	switch origin {
+	case "https://hub.triax.football",
+		"http://localhost:3000",
+		"http://localhost:8080":
+		return true
+	}
+	return false
+}
+
 func isApplicationAdmin(ctx context.Context, slackID string) (bool, error) {
 	client, err := datastore.NewClient(ctx, os.Getenv("GOOGLE_CLOUD_PROJECT"))
 	if err != nil {
@@ -80,7 +92,7 @@ func CreateApplication(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if input.Type == "onboarding" {
+	if input.Type == "onboarding" && isAllowedOrigin(req.Header.Get("Origin")) {
 		go func() {
 			api := slack.New(os.Getenv("SLACK_BOT_USER_OAUTH_TOKEN"))
 			msg := fmt.Sprintf("<!channel> 新しい入部申請が届きました。\nhttps://hub.triax.football/applications")


### PR DESCRIPTION
## Summary

- 入部申請フォーム（`/applications/onboarding`）の送信完了後、Slack `#入部退部者処理`（`C06SZGR7L1W`）に `@channel` メンション付きで通知を投稿する
- Slack 通知は goroutine で非同期実行するため、Slack 障害時も申請フォームのレスポンスに影響しない

## Closes

Closes #593

## Changes

- `server/api/application.go`: `CreateApplication()` に Slack 通知 goroutine を追加
  - `type == "onboarding"` の場合のみ送信
  - メッセージ: `<!channel> 新しい入部申請が届きました。\nhttps://hub.triax.football/applications`
  - エラー時は `[ERROR] 9010` でログ出力

## Test Plan

> 注: このセクションは PR 作成時点での Issue #593 `## 受け入れ条件` のスナップショット。

### 検証方針

- 対象画面: 入部申請フォーム `/applications/onboarding`
- URL:
  - local: http://localhost:8080/applications/onboarding
  - prod: https://hub.triax.football/applications/onboarding
- 認証: 不要（公開フォーム）
- 前提データ: Slack Bot が `C06SZGR7L1W` チャンネルに参加していること

### 検証項目

- [ ] [UI][SIDE-EFFECT] `/applications/onboarding` でフォームに必要事項を入力して送信 → Slack `#入部退部者処理` チャンネルに `@channel` メンション付き通知が届くこと
- [ ] [UI][SIDE-EFFECT] 通知メッセージに `https://hub.triax.football/applications` へのリンクが含まれること
- [ ] [LOGIC] Slack API がエラーを返した場合でも、申請フォームの送信レスポンスが正常（HTTP 200）で返ること
- [x] [BUILD] `go build -v ./...` がエラーなく完了すること

## Verification

- [BUILD] `go build -v ./...` → 成功 ✅
- [UI][SIDE-EFFECT] Slack 通知はデプロイ後に実環境で手動確認が必要