### PR TITLE
fix(env-provision): HTTP ヘルスチェック・seed 冪等性・ポート衝突検出を改善

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,6 +98,12 @@ func main() {
 	// ここでは /api/1/public/applications に配置して競合を避ける。
 	r.With(filters.MaxBodySize(512<<10)).Post("/api/1/public/applications", api.CreateApplication)
 
+	// ヘルスチェック（認証不要・Datastore 非依存）
+	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	})
+
 	// Unauthorized pages
 	smallBody := filters.MaxBodySize(1 << 20) // 1MB
 	r.With(smallBody).Post("/login", controllers.Login)

--- a/scripts/env-provision
+++ b/scripts/env-provision
@@ -15,9 +15,37 @@ if [[ -z "$VERB" ]]; then
   exit 1
 fi
 
-# ID から 0-99 のオフセットを算出（並列 env 間のポート衝突を回避）
+# ID から 0-99 のオフセットを算出。既存 env との衝突は offset ファイルを参照して回避する。
 _port_offset() {
-  printf '%s' "${1}" | cksum | awk '{print $1 % 100}'
+  local id="$1"
+  local preferred
+  preferred=$(printf '%s' "$id" | cksum | awk '{print $1 % 100}')
+
+  # 実行中の他の env が記録した使用済みオフセットを収集（自分自身の workdir は除外）
+  local my_workdir
+  my_workdir=$(_workdir "$id")
+  local used=()
+  for f in /tmp/hub-env-*/offset; do
+    [[ -f "$f" ]] && [[ "$f" != "${my_workdir}/offset" ]] && used+=("$(cat "$f")")
+  done
+
+  # preferred から衝突しないオフセットを 0-99 の範囲で探す
+  local i
+  for i in $(seq 0 99); do
+    local candidate=$(( (preferred + i) % 100 ))
+    local conflict=false
+    if [[ ${#used[@]} -gt 0 ]]; then
+      local u
+      for u in "${used[@]}"; do
+        [[ "$u" == "$candidate" ]] && conflict=true && break
+      done
+    fi
+    if ! $conflict; then echo "$candidate"; return; fi
+  done
+
+  printf '{"ready":false,"id":"%s","diagnostics":[{"check":"port-offset","status":"fail","detail":"port collision — all 100 offsets in use","remediation":"teardown unused envs: scripts/env-provision teardown <id>"}]}\n' \
+    "$id" >&2
+  exit 1
 }
 
 # PID / ログの作業ディレクトリ
@@ -104,6 +132,13 @@ _provision() {
 
   mkdir -p "$workdir" "$datadir"
 
+  # seed が必要かを emulator 起動前に確定する（起動後は emulator がファイルを書き込む）
+  local seed_needed=false
+  [[ -z "$(ls -A "$datadir" 2>/dev/null)" ]] && seed_needed=true
+
+  # オフセットをファイルに記録（他の env との衝突検出用、teardown で workdir ごと削除される）
+  echo "$offset" > "${workdir}/offset"
+
   # id に対応する worktree があれば、そのソースを使う（なければ main リポジトリ）
   local source_root="${REPO_ROOT}"
   local worktree_candidate="${REPO_ROOT}/.worktrees/${id}"
@@ -138,8 +173,10 @@ _provision() {
   done
 
   # --- Seed: devdata/2024-1201-200205 をエミュレータへインポート ---
+  # datadir が空（初回 provision または teardown 後）のときのみ実行する。
+  # emulator 起動後は datadir にファイルが書き込まれるため、seed_needed は起動前に確定済み。
   local seed_meta="${REPO_ROOT}/devdata/2024-1201-200205/2024-1201-200205.overall_export_metadata"
-  if [[ -f "$seed_meta" ]]; then
+  if [[ "$seed_needed" == true ]] && [[ -f "$seed_meta" ]]; then
     # REST API（ヘルスチェックエンドポイント）が応答するまで待つ（最大 20 秒）
     local api_retries=20
     while ! curl -sf "http://localhost:${ds_port}/" >/dev/null 2>&1; do
@@ -174,12 +211,12 @@ _provision() {
     > "${workdir}/api.log" 2>&1 &
   echo $! > "${workdir}/api.pid"
 
-  # API サーバの起動を待つ（最大 30 秒）
+  # API サーバの起動を待つ（最大 30 秒、/healthz が 200 を返すまで）
   retries=30
-  while ! nc -z localhost "${api_port}" 2>/dev/null; do
+  while ! curl -sf "http://localhost:${api_port}/healthz" >/dev/null 2>&1; do
     retries=$((retries - 1))
     if [[ $retries -le 0 ]]; then
-      printf '{"ready":false,"id":"%s","diagnostics":["Go API server timed out on port %s. See %s/api.log"]}\n' \
+      printf '{"ready":false,"id":"%s","diagnostics":[{"check":"api","status":"fail","detail":"timeout waiting for /healthz on port %s","remediation":"check %s/api.log"}]}\n' \
         "$id" "$api_port" "$workdir"
       exit 1
     fi
@@ -194,12 +231,12 @@ _provision() {
     > "${workdir}/vite.log" 2>&1 &
   echo $! > "${workdir}/vite.pid"
 
-  # Vite の起動を待つ（最大 30 秒）
+  # Vite の起動を待つ（最大 30 秒、HTTP 200 を返すまで）
   retries=30
-  while ! nc -z localhost "${vite_port}" 2>/dev/null; do
+  while ! curl -sf "http://localhost:${vite_port}/" >/dev/null 2>&1; do
     retries=$((retries - 1))
     if [[ $retries -le 0 ]]; then
-      printf '{"ready":false,"id":"%s","diagnostics":["Vite dev server timed out on port %s. See %s/vite.log"]}\n' \
+      printf '{"ready":false,"id":"%s","diagnostics":[{"check":"vite","status":"fail","detail":"timeout waiting for HTTP on port %s","remediation":"check %s/vite.log"}]}\n' \
         "$id" "$vite_port" "$workdir"
       exit 1
     fi

--- a/scripts/env-provision
+++ b/scripts/env-provision
@@ -11,7 +11,7 @@ PROJECT_ID="${PROJECT_ID:-triax-football}"
 
 if [[ -z "$VERB" ]]; then
   echo "Usage: $0 <verb> [<id>]" >&2
-  echo "  verbs: provision, doctor, teardown, status" >&2
+  echo "  verbs: provision, doctor, manifest, teardown, status" >&2
   exit 1
 fi
 
@@ -85,36 +85,53 @@ _setup_worktree_symlinks() {
   mkdir -p "${REPO_ROOT}/client/dest"
 }
 
+# ---------------------------------------------------------------- manifest ---
+# エージェントが「何が shared で何が per-env か」を判断するためのメタ情報を返す。
+# per_env に列挙されたリソースは provision が管理するため、エージェントは
+# これらを理由に検証を SKIP しない。
+_manifest() {
+  printf '{"shared":{"description":"doctor が検証する前提条件。provision は関与しない","requires":[{"id":"gcloud","check":"command -v gcloud","detail":"gcloud CLI"},{"id":"datastore_component","check":"gcloud components list","detail":"cloud-datastore-emulator コンポーネント"},{"id":"go","check":"command -v go","detail":"Go runtime"},{"id":"npm","check":"command -v npm","detail":"Node.js / npm"},{"id":"secrets","check":"test -f secrets.local.yaml","detail":"secrets.local.yaml"}]},"per_env":{"description":"provision <id> が idempotent に管理するリソース。consumer はこれらを理由に検証を SKIP しない","provisions":[{"id":"datastore_emulator","lifecycle":"provision/teardown","detail":"Datastore エミュレーター（<id> 単位でポートとデータディレクトリを分離）"},{"id":"seed_import","lifecycle":"provision (初回のみ、冪等)","detail":"devdata/2024-1201-200205 からの seed データ投入"},{"id":"go_api_server","lifecycle":"provision/teardown","detail":"Go API サーバー"},{"id":"vite_dev_server","lifecycle":"provision/teardown","detail":"Vite dev server"}]}}\n'
+}
+
 # ------------------------------------------------------------------ doctor ---
 _doctor() {
   local ok=true
   local issues=()
 
   _check() {
-    local name="$1" cmd="$2" detail_ok="$3" detail_fail="$4" fix="$5"
+    local name="$1" cmd="$2" detail_ok="$3" detail_fail="$4" fix="$5" manifest_item="${6:-}"
+    local entry
     if eval "$cmd" >/dev/null 2>&1; then
-      issues+=("{\"check\":\"${name}\",\"status\":\"pass\",\"detail\":\"${detail_ok}\"}")
+      entry="{\"check\":\"${name}\",\"status\":\"pass\",\"detail\":\"${detail_ok}\""
     else
       ok=false
-      issues+=("{\"check\":\"${name}\",\"status\":\"fail\",\"detail\":\"${detail_fail}\",\"remediation\":\"${fix}\"}")
+      entry="{\"check\":\"${name}\",\"status\":\"fail\",\"detail\":\"${detail_fail}\",\"remediation\":\"${fix}\""
     fi
+    [[ -n "$manifest_item" ]] && entry="${entry},\"manifest_item\":\"${manifest_item}\""
+    issues+=("${entry}}")
   }
 
-  _check "gcloud"          "command -v gcloud"      "gcloud CLI found" "gcloud CLI not found"          "Install Google Cloud SDK"
+  _check "gcloud"          "command -v gcloud"      "gcloud CLI found" "gcloud CLI not found"          "Install Google Cloud SDK"                                    "gcloud"
   _check "datastore-comp"  "gcloud components list --format='value(id)' 2>/dev/null | grep -q cloud-datastore-emulator" \
                                                     "cloud-datastore-emulator installed" "cloud-datastore-emulator not installed" \
-                                                    "gcloud components install cloud-datastore-emulator"
-  _check "go"              "command -v go"          "go found"          "go not found"                  "Install Go"
-  _check "npm"             "command -v npm"          "npm found"         "npm not found"                 "Install Node.js"
+                                                    "gcloud components install cloud-datastore-emulator"                          "datastore_component"
+  _check "go"              "command -v go"          "go found"          "go not found"                  "Install Go"                                                  "go"
+  _check "npm"             "command -v npm"          "npm found"         "npm not found"                 "Install Node.js"                                             "npm"
   _check "secrets"         "test -f '${REPO_ROOT}/secrets.local.yaml'" \
                                                     "secrets.local.yaml found" "secrets.local.yaml not found" \
-                                                    "cp secrets.example.yaml secrets.local.yaml && fill in values"
+                                                    "cp secrets.example.yaml secrets.local.yaml && fill in values"                "secrets"
+
+  local all_pass=true
+  for item in "${issues[@]}"; do
+    [[ "$item" == *'"status":"fail"'* ]] && all_pass=false && break
+  done
 
   local checks_json
   local joined
   joined=$(printf '%s,' "${issues[@]}")
   checks_json="[${joined%,}]"
-  printf '{"ok":%s,"checks":%s}\n' "$ok" "$checks_json"
+  printf '{"ok":%s,"checks":%s,"provision_readiness":{"ready":%s,"note":"per_env リソース（Datastore エミュレーター・Go API・Vite）は provision verb が管理する。doctor は shared 前提条件のみ検証する"}}\n' \
+    "$ok" "$checks_json" "$all_pass"
 }
 
 # --------------------------------------------------------------- provision ---
@@ -297,6 +314,7 @@ _status() {
 case "$VERB" in
   provision)  _provision "$ID" ;;
   doctor)     _doctor ;;
+  manifest)   _manifest ;;
   teardown)   _teardown "$ID" ;;
   status)     _status "$ID" ;;
   *)


### PR DESCRIPTION
## Summary

- **#597**: \`nc -z\` を HTTP ヘルスチェックに置き換え。\`main.go\` に \`/healthz\` エンドポイント（認証不要・Datastore 非依存）を追加し、Go API は \`/healthz\` が 200、Vite は \`curl -sf http://localhost:{port}/\` が 200 を返すまで待機するよう変更。
- **#598**: emulator 起動前に \`seed_needed\` フラグを確定し、\`devdata/env-<id>\` が空のときのみ seed をインポート。再 provision 時のデータ重複・不整合を解消。
- **#599**: \`_port_offset()\` にオフセットファイル方式の衝突検出を追加。衝突時は次の空きオフセットへ自動スライド。全 100 オフセット枯渇時は \`port collision\` を含む JSON エラーを出力。
- **追加**: \`manifest\` verb を追加。\`shared\`（doctor が検証する前提条件）と \`per_env\`（provision が管理するリソース）を JSON で返し、エージェントの誤 SKIP を防ぐ。\`doctor\` 出力に \`manifest_item\` / \`provision_readiness\` を追加。

## Test Plan

- [ ] [BUILD] \`go build -v ./...\` がエラーなく完了すること
- [ ] [LOGIC] \`GET /healthz\` が認証なしで \`{"ok":true}\` と HTTP 200 を返すこと
- [ ] [LOGIC] \`scripts/env-provision manifest\` が \`shared\` / \`per_env\` を含む JSON を返すこと
- [ ] [LOGIC] \`scripts/env-provision doctor\` が \`manifest_item\` / \`provision_readiness\` を含む JSON を返すこと
- [ ] [LOGIC] \`scripts/env-provision provision test-id\` を実行し、\`{"ready":true,...}\` が出力されること
- [ ] [LOGIC] teardown せずに \`provision test-id\` を再実行し、seed インポートがスキップされること
- [ ] [LOGIC] \`teardown test-id\` → \`provision test-id\` で seed が再インポートされること
- [ ] [LOGIC] 衝突する 2 つの ID を provision した場合、後者が別オフセットで起動するか \`port collision\` を含む JSON を出力すること

Closes #597, #598, #599