### PR TITLE
feat(observability): FE/BE エラーを Slack へアラート投稿する可観測性基盤

### DIFF
--- a/client/repository/observability.ts
+++ b/client/repository/observability.ts
@@ -1,0 +1,47 @@
+/**
+ * フロントエンドのエラーをサーバ（/api/1/client-errors）へ報告する。
+ * 報告経路は決して throw しない（エラー報告でアプリを二次的に壊さない）。
+ */
+
+export interface ClientErrorInput {
+  message: string;
+  stack?: string;
+  url?: string;
+  ts?: number;
+}
+
+// 同一メッセージの短時間連投を抑制する（unhandledrejection の連鎖等によるノイズ対策）。
+let lastMessage = "";
+let lastSentAt = 0;
+const DEDUP_WINDOW_MS = 10_000;
+
+export function reportClientError(input: ClientErrorInput): void {
+  try {
+    const now = Date.now();
+    if (input.message === lastMessage && now - lastSentAt < DEDUP_WINDOW_MS) return;
+    lastMessage = input.message;
+    lastSentAt = now;
+
+    const env = import.meta.env as Record<string, string | undefined>;
+    const payload = {
+      message: input.message,
+      stack: input.stack,
+      url: input.url ?? (typeof location !== "undefined" ? location.href : undefined),
+      userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      release: env?.VITE_RELEASE,
+      ts: input.ts ?? now,
+    };
+
+    // keepalive: ページ遷移・クラッシュ中でも送信を試みる
+    void fetch("/api/1/client-errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    }).catch(() => {
+      /* 報告の失敗は握りつぶす */
+    });
+  } catch {
+    /* 報告経路で発生した例外は無視する */
+  }
+}

--- a/client/src/ErrorFallback.tsx
+++ b/client/src/ErrorFallback.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { reportClientError } from "../repository/observability";
+
+/**
+ * route 描画中に投げられた例外を捕捉するフォールバック UI。
+ * TanStack Router の defaultErrorComponent として全 route に適用する。
+ * マウント時にエラーをサーバへ報告し、ユーザには再読み込み導線を提示する。
+ */
+export default function ErrorFallback({ error }: { error: Error }) {
+  useEffect(() => {
+    reportClientError({
+      message: error?.message || String(error),
+      stack: error?.stack,
+    });
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-8 text-center">
+      <div className="text-3xl mb-3">⚠️</div>
+      <h1 className="text-lg font-bold text-gray-800 mb-2">エラーが発生しました</h1>
+      <p className="text-sm text-gray-500 mb-6 max-w-xs">
+        問題が開発チームに自動で報告されました。お手数ですが、ページの再読み込みをお試しください。
+      </p>
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium cursor-pointer"
+        onClick={() => location.reload()}
+      >
+        再読み込み
+      </button>
+    </div>
+  );
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,23 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from '@tanstack/react-router';
 import { router } from './router';
+import { reportClientError } from '../repository/observability';
+
+// Error Boundary で捕捉できない大域エラー（イベントハンドラ・非同期等）を報告する
+window.addEventListener('error', (e) => {
+  reportClientError({
+    message: e.message || 'window.onerror',
+    stack: e.error?.stack,
+    url: e.filename ? `${e.filename}:${e.lineno}:${e.colno}` : undefined,
+  });
+});
+window.addEventListener('unhandledrejection', (e) => {
+  const reason = e.reason as { message?: string; stack?: string } | undefined;
+  reportClientError({
+    message: reason?.message || String(e.reason) || 'unhandledrejection',
+    stack: reason?.stack,
+  });
+});
 
 createRoot(document.getElementById('app')!).render(
   <StrictMode>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRouter, createRoute, createRootRoute, Outlet } from '@tanstack/react-router';
 import { AppProvider } from './context';
+import ErrorFallback from './ErrorFallback';
 
 import Top from './pages/index';
 import Login from './pages/login';
@@ -165,7 +166,11 @@ const routeTree = rootRoute.addChildren([
   applicationsRoute,
 ]);
 
-export const router = createRouter({ routeTree });
+export const router = createRouter({
+  routeTree,
+  // route 描画中の例外を全 route で捕捉し、フォールバック表示＋サーバ報告を行う
+  defaultErrorComponent: ErrorFallback,
+});
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,9 @@ func main() {
 
 	r := chi.NewRouter()
 
+	// panic を捕捉して 500 を返しつつ Slack へアラート（プロセスを落とさない）
+	r.Use(filters.Recovery)
+
 	// セキュリティヘッダー
 	r.Use(filters.SecurityHeaders)
 
@@ -49,6 +52,8 @@ func main() {
 
 	v1.Group(func(r chi.Router) {
 		r.Use(filters.MaxBodySize(1 << 20)) // 1MB
+		// フロントエンドのエラー報告を受け取り Slack へアラート
+		r.Post("/client-errors", api.ReportClientError)
 		r.Get("/members/{id}", api.GetMember)
 		r.Post("/members/{id}/props", api.UpdateMemberProps)
 		r.Get("/members/{id}/hp-profile", api.GetHPProfile)

--- a/secrets.example.yaml
+++ b/secrets.example.yaml
@@ -26,6 +26,12 @@ env_variables:
   # IAM: App Engine SA に roles/storage.objectAdmin を付与
   GCS_HP_PHOTO_BUCKET: your-project-hp-photos
 
+  # Observability（エラーアラート投稿先）
+  # フロント／バックエンドの未捕捉エラーを投稿する Slack チャンネル ID。
+  # dev/prod でデプロイ環境（env_variables）が分かれるため、環境ごとに別チャンネルを設定する。
+  # 未設定の場合はアラート投稿を行わない（no-op）。
+  SLACK_CHANNEL_ALERTS: CXXXXXXXXXX
+
   # Application
   APP_ICON_URL: https://drive.google.com/uc?id=xxxxxxxxxxxxxxxxxxxxxxxx
   HUB_WEBPAGE_BASE_URL: https://hub.yourdomain.com

--- a/server/api/clienterrors.go
+++ b/server/api/clienterrors.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/otiai10/marmoset"
+	"github.com/triax/hub/server/filters"
+	"github.com/triax/hub/server/observability"
+)
+
+// ReportClientError はフロントエンドからのエラー報告を受け取り、
+// 登録された Slack チャンネルへアラートを送る。レスポンスは 204 No Content。
+//
+// /api/1/* 配下（JWT 認証）に置くため、報告には呼び出しユーザの Slack ID を付与する。
+func ReportClientError(w http.ResponseWriter, req *http.Request) {
+	render := marmoset.Render(w)
+
+	var input struct {
+		Message   string `json:"message"`
+		Stack     string `json:"stack"`
+		URL       string `json:"url"`
+		UserAgent string `json:"userAgent"`
+		Release   string `json:"release"`
+		TS        int64  `json:"ts"` // epoch ミリ秒
+	}
+	if err := json.NewDecoder(req.Body).Decode(&input); err != nil {
+		render.JSON(http.StatusBadRequest, marmoset.P{"error": err.Error()})
+		return
+	}
+	if input.Message == "" {
+		render.JSON(http.StatusBadRequest, marmoset.P{"error": "message is required"})
+		return
+	}
+
+	report := observability.Report{
+		Source:    "frontend",
+		Message:   input.Message,
+		Stack:     input.Stack,
+		URL:       input.URL,
+		UserAgent: input.UserAgent,
+		Release:   input.Release,
+		User:      filters.GetSessionUserContext(req),
+	}
+	if input.TS > 0 {
+		report.Time = time.UnixMilli(input.TS)
+	}
+	observability.Notify(report)
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/api/clienterrors_test.go
+++ b/server/api/clienterrors_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/triax/hub/server/filters"
+)
+
+// TestReportClientError_Valid は、正しい body を送ると 204 を返すことを検証する。
+// SLACK_CHANNEL_ALERTS 未設定の環境では observability.Notify は no-op なので Slack へは投稿されない。
+func TestReportClientError_Valid(t *testing.T) {
+	body := `{"message":"Minified React error #130","stack":"at RSVPModal","url":"https://hub.triax.football/events/x","ts":1700000000000}`
+	req := httptest.NewRequest(http.MethodPost, "/api/1/client-errors", strings.NewReader(body))
+	// /api/1/* は認証下に置くため、セッションユーザを付与した状態を再現する。
+	req = filters.SetSessionUserContext(req, "U12345678")
+	rec := httptest.NewRecorder()
+
+	ReportClientError(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body=%s)", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+}
+
+// TestReportClientError_MissingMessage は、message 欠落時に 400 を返すことを検証する。
+func TestReportClientError_MissingMessage(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/1/client-errors", strings.NewReader(`{"stack":"x"}`))
+	req = filters.SetSessionUserContext(req, "U12345678")
+	rec := httptest.NewRecorder()
+
+	ReportClientError(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// TestReportClientError_InvalidJSON は、壊れた JSON で 400 を返すことを検証する。
+func TestReportClientError_InvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/1/client-errors", strings.NewReader(`{not json`))
+	req = filters.SetSessionUserContext(req, "U12345678")
+	rec := httptest.NewRecorder()
+
+	ReportClientError(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}

--- a/server/filters/recovery.go
+++ b/server/filters/recovery.go
@@ -1,0 +1,43 @@
+package filters
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/otiai10/marmoset"
+	"github.com/triax/hub/server/observability"
+)
+
+// Recovery は panic を捕捉し、500 を返しつつ Slack へアラートを送る middleware。
+// 本番でハンドラが panic してもプロセスを落とさず、可観測性を確保する。
+func Recovery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				stack := string(debug.Stack())
+				log.Printf("[ERROR] 10001 panic recovered: %v\n%s", rec, stack)
+				observability.Notify(observability.Report{
+					Source:  "backend/panic",
+					Message: fmt.Sprintf("%v", rec),
+					Stack:   stack,
+					URL:     r.Method + " " + r.URL.Path,
+					User:    sessionUserSafe(r),
+				})
+				marmoset.Render(w).JSON(http.StatusInternalServerError, marmoset.P{"error": "internal server error"})
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// sessionUserSafe はセッションユーザ ID を panic せずに取得する。
+// Recovery は認証前のルートも含めて全リクエストを包むため、
+// セッション未設定でも安全に空文字を返す必要がある。
+func sessionUserSafe(r *http.Request) string {
+	if v, ok := r.Context().Value(SessionContextKey).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/server/filters/recovery_test.go
+++ b/server/filters/recovery_test.go
@@ -1,0 +1,45 @@
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRecovery_RecoversPanic は、ハンドラが panic しても
+// middleware が 500 を返し、panic を呼び出し元へ伝播しないことを検証する。
+// SLACK_CHANNEL_ALERTS 未設定の環境では observability.Notify は no-op なので副作用は発生しない。
+func TestRecovery_RecoversPanic(t *testing.T) {
+	h := Recovery(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/1/explode", nil)
+	rec := httptest.NewRecorder()
+
+	// panic が伝播するとこの呼び出しが落ちる（テスト失敗）。
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+// TestRecovery_PassThrough は、panic しない通常のレスポンスをそのまま通すことを検証する。
+func TestRecovery_PassThrough(t *testing.T) {
+	h := Recovery(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Body.String() != "ok" {
+		t.Fatalf("body = %q, want %q", rec.Body.String(), "ok")
+	}
+}

--- a/server/observability/alert.go
+++ b/server/observability/alert.go
@@ -1,0 +1,151 @@
+// Package observability はフロント／バックエンドで発生したエラーを
+// 登録された Slack チャンネルへアラート投稿するためのヘルパーを提供する。
+//
+// 通知先チャンネルは環境変数 SLACK_CHANNEL_ALERTS で解決する。
+// GAE は dev/prod でデプロイ環境（env_variables）が分かれるため、
+// この 1 変数だけで環境ごとの通知先切り替えが成立する。
+package observability
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// alertChannelEnv は通知先チャンネル ID を解決する環境変数名。
+const alertChannelEnv = "SLACK_CHANNEL_ALERTS"
+
+// dedupWindow は同一エラーの連投を抑制する時間窓。
+const dedupWindow = 60 * time.Second
+
+// maxStackLen は Slack のテキストブロック上限（3000字）に収めるためのスタック切り詰め長。
+const maxStackLen = 2600
+
+// Report は 1 件のエラーアラートに含める情報。任意項目は空でよい。
+type Report struct {
+	Source    string    // 発生元（例: "frontend", "backend/panic"）
+	Message   string    // エラーメッセージ
+	Stack     string    // スタックトレース
+	URL       string    // 発生 URL / エンドポイント
+	UserAgent string    // クライアント UserAgent
+	Release   string    // ビルド識別子
+	User      string    // Slack ユーザ ID 等
+	Time      time.Time // 発生時刻（zero 値なら送信時刻で補完）
+}
+
+// 同一エラーの短時間連投を抑制するための簡易 dedup 状態。
+var (
+	dedupMu       sync.Mutex
+	dedupLastSent = map[string]time.Time{}
+)
+
+// Notify はエラーアラートを Slack へ非同期投稿する fire-and-forget なヘルパー。
+//
+// アラート送信自体が呼び出し元（recovery middleware 等）を二次破壊しないよう、
+// 内部で goroutine + recover ガードする。通知先チャンネル（SLACK_CHANNEL_ALERTS）が
+// 未設定の環境（ローカル開発・テスト等）では no-op となる。
+func Notify(r Report) {
+	channel := os.Getenv(alertChannelEnv)
+	if channel == "" {
+		log.Printf("[observability] %s 未設定のためアラートを送信しません: %s", alertChannelEnv, r.Message)
+		return
+	}
+	if r.Time.IsZero() {
+		r.Time = time.Now()
+	}
+	if suppressed(r) {
+		return
+	}
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Printf("[observability] アラート送信中に panic: %v", rec)
+			}
+		}()
+		api := slack.New(os.Getenv("SLACK_BOT_USER_OAUTH_TOKEN"))
+		if _, _, err := api.PostMessage(channel, slack.MsgOptionBlocks(r.blocks()...)); err != nil {
+			log.Printf("[observability] アラート投稿に失敗: %v", err)
+		}
+	}()
+}
+
+// suppressed は直近 dedupWindow 内に同一（発生元＋メッセージ）のアラートを
+// 送っていれば true を返し、送信を抑制する。
+func suppressed(r Report) bool {
+	key := r.Source + "|" + r.Message
+	dedupMu.Lock()
+	defer dedupMu.Unlock()
+	now := time.Now()
+	if last, ok := dedupLastSent[key]; ok && now.Sub(last) < dedupWindow {
+		return true
+	}
+	dedupLastSent[key] = now
+	return false
+}
+
+// envLabel はアラートに表示するデプロイ環境ラベルを返す。
+// GAE では GOOGLE_CLOUD_PROJECT がプロジェクト（dev/prod）を表す。
+func envLabel() string {
+	if p := os.Getenv("GOOGLE_CLOUD_PROJECT"); p != "" {
+		return p
+	}
+	return "local"
+}
+
+// blocks は Report を原因特定に十分な情報を含む Slack Block Kit へ整形する。
+func (r Report) blocks() []slack.Block {
+	header := slack.NewHeaderBlock(
+		slack.NewTextBlockObject(slack.PlainTextType, "🚨 エラー検知", true, false),
+	)
+
+	fields := []*slack.TextBlockObject{
+		slack.NewTextBlockObject(slack.MarkdownType, "*環境:*\n"+envLabel(), false, false),
+		slack.NewTextBlockObject(slack.MarkdownType, "*発生元:*\n"+orDash(r.Source), false, false),
+		slack.NewTextBlockObject(slack.MarkdownType, "*時刻:*\n"+r.Time.Format(time.RFC3339), false, false),
+		slack.NewTextBlockObject(slack.MarkdownType, "*ユーザ:*\n"+orDash(r.User), false, false),
+	}
+	meta := slack.NewSectionBlock(nil, fields, nil)
+
+	body := fmt.Sprintf("*メッセージ:*\n```%s```", truncate(orDash(r.Message), maxStackLen))
+	if r.URL != "" {
+		body += "\n*発生箇所:* `" + r.URL + "`"
+	}
+	if r.Release != "" {
+		body += "\n*リリース:* `" + r.Release + "`"
+	}
+	if r.UserAgent != "" {
+		body += "\n*UA:* " + r.UserAgent
+	}
+	msg := slack.NewSectionBlock(
+		slack.NewTextBlockObject(slack.MarkdownType, body, false, false), nil, nil,
+	)
+
+	blocks := []slack.Block{header, meta, msg}
+	if strings.TrimSpace(r.Stack) != "" {
+		stack := slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, "*スタック:*\n```"+truncate(r.Stack, maxStackLen)+"```", false, false),
+			nil, nil,
+		)
+		blocks = append(blocks, stack)
+	}
+	return blocks
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n…(truncated)"
+}


### PR DESCRIPTION
## Summary

フロント／バックエンドの未捕捉エラーを、登録された Slack チャンネル（env var `SLACK_CHANNEL_ALERTS`）へ詳細付きで自動アラートする可観測性基盤を追加します。今回の発端（本番でフロントが React #130 で落ち、テキスト連絡で初めて発覚 → #604）のような事象を即座に検知できるようにします。

## Closes

Closes #605

## Changes

**バックエンド**
- `server/observability/alert.go` — `Notify(Report)`: エラーを Slack へ非同期投稿する fire-and-forget ヘルパー。通知先は `SLACK_CHANNEL_ALERTS` で解決し、Block Kit で環境/発生元/時刻/ユーザ/メッセージ/URL/スタックを整形。簡易 dedup で連投抑制。**未設定時は no-op**（ローカル/テストで安全）。送信は内部 goroutine + recover ガードで二次破壊を防止
- `server/filters/recovery.go` — `Recovery` middleware: panic を捕捉し 500 を返しつつ Slack へアラート（プロセスを落とさない）。`main.go` の最外段に `Use`
- `server/api/clienterrors.go` — `POST /api/1/client-errors`: フロントのエラー報告を受け、session のユーザ ID を付与して `Notify` → 204
- `secrets.example.yaml` — `SLACK_CHANNEL_ALERTS` を追記（dev/prod で別チャンネル）

**フロントエンド**
- `client/src/ErrorFallback.tsx` — route 描画エラーのフォールバック UI。`router.tsx` の `defaultErrorComponent` に設定し、全 route のクラッシュ（#604 級含む）を捕捉して自動報告
- `client/src/main.tsx` — `window.error` / `unhandledrejection` を登録し未捕捉エラーを報告
- `client/repository/observability.ts` — `/api/1/client-errors` へ POST する reporter（keepalive・連投 dedup・自身は throw しない）

**テスト**
- `server/filters/recovery_test.go` / `server/api/clienterrors_test.go`（本リポジトリ初の Go テスト）

## 設計上の判断

- **通知先は env var で解決**（Datastore Kind ではなく）。GAE は dev/prod で `env_variables` が分かれるため、`SLACK_CHANNEL_ALERTS` 1 つで環境別通知先が成立し、ハードコード（旧 `C06SZGR7L1W`）を脱却。受け入れ条件「env var もしくは Datastore」を満たす最小実装
- Slack 投稿は **`[SIDE-EFFECT]`** のため CI/自動検証では実投稿せず（`Notify` は env 未設定で no-op）、投稿経路はテスト用 dev チャンネルで手動確認する想定

## Test Plan

> 注: このセクションは PR 作成時点での Issue #605 `## 受け入れ条件` のスナップショット。
> verification の source-of-truth は Issue 側にあり、`/uat` は常に Issue を authoritative として読む。

- [x] [BUILD] フロント `npm run build` / バックエンド `go build ./...` がエラーなく完了すること
- [x] [LOGIC] `POST /api/1/client-errors` にサンプルエラーを送ると 2xx が返ること（`clienterrors_test.go`: 正常→204 / message欠落→400 / 不正JSON→400）／設定した dev チャンネルへの投稿は `[SIDE-EFFECT]` のため手動確認
- [x] [LOGIC][SIDE-EFFECT] バックエンドで panic → 500 応答かつプロセスが落ちないこと（`recovery_test.go` で検証）／dev チャンネルへのスタック付き投稿は手動確認
- [ ] [UI][SIDE-EFFECT] フロントで例外発生 → Error Boundary がフォールバック表示し、dev チャンネルへ発生URL・メッセージ・スタック付きで投稿されること（副作用のため手動。`SLACK_CHANNEL_ALERTS` を dev チャンネルに設定して実機確認）
- [x] [LOGIC] 通知先チャンネルが env var から解決され、ハードコードに依存しないこと（`os.Getenv("SLACK_CHANNEL_ALERTS")`）
- [ ] [MANUAL] 投稿内容に原因特定に十分な情報（メッセージ・スタック・発生箇所・環境・時刻・ユーザ）が含まれること（Block Kit 整形済、レビュー委譲）

## Verification

- `[BUILD]` `go build ./...` → OK / `npm run build` → 597 modules, built OK / `npm run lint` → クリーン
- `[LOGIC]` `go test ./...` → `server/api` `server/filters` ともに PASS
- `[UI]`/投稿系は `[SIDE-EFFECT]` のため自動スクショ・evidence なし（手動確認項目）

## Note

- 本リポジトリ初の Go テストを追加しています（`go test ./...` で実行可）。
- フロントの Error Boundary は #604（headless-ui v2 クラッシュ）のような描画エラーも捕捉対象です。#604 自体の修正は別 PR。