### PR TITLE
feat(observability): エラー報告を本番で実名化（コンポーネントスタック / keepNames / リクエスト文脈）

### DIFF
--- a/client/repository/observability.ts
+++ b/client/repository/observability.ts
@@ -6,6 +6,7 @@
 export interface ClientErrorInput {
   message: string;
   stack?: string;
+  componentStack?: string;
   url?: string;
   ts?: number;
 }
@@ -26,6 +27,7 @@ export function reportClientError(input: ClientErrorInput): void {
     const payload = {
       message: input.message,
       stack: input.stack,
+      componentStack: input.componentStack,
       url: input.url ?? (typeof location !== "undefined" ? location.href : undefined),
       userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
       release: env?.VITE_RELEASE,

--- a/client/src/ErrorFallback.tsx
+++ b/client/src/ErrorFallback.tsx
@@ -1,19 +1,10 @@
-import { useEffect } from "react";
-import { reportClientError } from "../repository/observability";
-
 /**
  * route 描画中に投げられた例外を捕捉するフォールバック UI。
  * TanStack Router の defaultErrorComponent として全 route に適用する。
- * マウント時にエラーをサーバへ報告し、ユーザには再読み込み導線を提示する。
+ * サーバへの報告は router の defaultOnCatch が担う（componentStack を含められるため）。
+ * 本コンポーネントは表示のみを担当する。
  */
-export default function ErrorFallback({ error }: { error: Error }) {
-  useEffect(() => {
-    reportClientError({
-      message: error?.message || String(error),
-      stack: error?.stack,
-    });
-  }, [error]);
-
+export default function ErrorFallback() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-8 text-center">
       <div className="text-3xl mb-3">⚠️</div>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,6 +1,7 @@
 import { createRouter, createRoute, createRootRoute, Outlet } from '@tanstack/react-router';
 import { AppProvider } from './context';
 import ErrorFallback from './ErrorFallback';
+import { reportClientError } from '../repository/observability';
 
 import Top from './pages/index';
 import Login from './pages/login';
@@ -168,8 +169,18 @@ const routeTree = rootRoute.addChildren([
 
 export const router = createRouter({
   routeTree,
-  // route 描画中の例外を全 route で捕捉し、フォールバック表示＋サーバ報告を行う
+  // route 描画中の例外を全 route で捕捉してフォールバック表示する
   defaultErrorComponent: ErrorFallback,
+  // 例外の報告はここで行う。defaultErrorComponent の props には componentStack が
+  // 渡らない（空文字固定）ため、React のコンポーネントスタックを含む errorInfo を
+  // 受け取れる defaultOnCatch でサーバへ報告する（描画クラッシュの犯人特定に有効）。
+  defaultOnCatch: (error, errorInfo) => {
+    reportClientError({
+      message: error?.message || String(error),
+      stack: error?.stack,
+      componentStack: errorInfo?.componentStack,
+    });
+  },
 });
 
 declare module '@tanstack/react-router' {

--- a/server/api/clienterrors.go
+++ b/server/api/clienterrors.go
@@ -18,12 +18,13 @@ func ReportClientError(w http.ResponseWriter, req *http.Request) {
 	render := marmoset.Render(w)
 
 	var input struct {
-		Message   string `json:"message"`
-		Stack     string `json:"stack"`
-		URL       string `json:"url"`
-		UserAgent string `json:"userAgent"`
-		Release   string `json:"release"`
-		TS        int64  `json:"ts"` // epoch ミリ秒
+		Message        string `json:"message"`
+		Stack          string `json:"stack"`
+		ComponentStack string `json:"componentStack"`
+		URL            string `json:"url"`
+		UserAgent      string `json:"userAgent"`
+		Release        string `json:"release"`
+		TS             int64  `json:"ts"` // epoch ミリ秒
 	}
 	if err := json.NewDecoder(req.Body).Decode(&input); err != nil {
 		render.JSON(http.StatusBadRequest, marmoset.P{"error": err.Error()})
@@ -35,13 +36,15 @@ func ReportClientError(w http.ResponseWriter, req *http.Request) {
 	}
 
 	report := observability.Report{
-		Source:    "frontend",
-		Message:   input.Message,
-		Stack:     input.Stack,
-		URL:       input.URL,
-		UserAgent: input.UserAgent,
-		Release:   input.Release,
-		User:      filters.GetSessionUserContext(req),
+		Source:         "frontend",
+		Message:        input.Message,
+		Stack:          input.Stack,
+		ComponentStack: input.ComponentStack,
+		URL:            input.URL,
+		Referer:        req.Referer(),
+		UserAgent:      input.UserAgent,
+		Release:        input.Release,
+		User:           filters.GetSessionUserContext(req),
 	}
 	if input.TS > 0 {
 		report.Time = time.UnixMilli(input.TS)

--- a/server/api/clienterrors_test.go
+++ b/server/api/clienterrors_test.go
@@ -12,7 +12,7 @@ import (
 // TestReportClientError_Valid は、正しい body を送ると 204 を返すことを検証する。
 // SLACK_CHANNEL_ALERTS 未設定の環境では observability.Notify は no-op なので Slack へは投稿されない。
 func TestReportClientError_Valid(t *testing.T) {
-	body := `{"message":"Minified React error #130","stack":"at RSVPModal","url":"https://hub.triax.football/events/x","ts":1700000000000}`
+	body := `{"message":"Minified React error #130","stack":"at a (index-xxxx.js:1:2345)","componentStack":"\n    at RSVPModal\n    at EventView","url":"https://hub.triax.football/events/x","ts":1700000000000}`
 	req := httptest.NewRequest(http.MethodPost, "/api/1/client-errors", strings.NewReader(body))
 	// /api/1/* は認証下に置くため、セッションユーザを付与した状態を再現する。
 	req = filters.SetSessionUserContext(req, "U12345678")

--- a/server/filters/recovery.go
+++ b/server/filters/recovery.go
@@ -19,11 +19,13 @@ func Recovery(next http.Handler) http.Handler {
 				stack := string(debug.Stack())
 				log.Printf("[ERROR] 10001 panic recovered: %v\n%s", rec, stack)
 				observability.Notify(observability.Report{
-					Source:  "backend/panic",
-					Message: fmt.Sprintf("%v", rec),
-					Stack:   stack,
-					URL:     r.Method + " " + r.URL.Path,
-					User:    sessionUserSafe(r),
+					Source:    "backend/panic",
+					Message:   fmt.Sprintf("%v (%T)", rec, rec), // panic 値の型も含める
+					Stack:     stack,
+					URL:       r.Method + " " + r.URL.RequestURI(), // クエリ文字列を含む
+					Referer:   r.Referer(),
+					UserAgent: r.UserAgent(),
+					User:      sessionUserSafe(r),
 				})
 				marmoset.Render(w).JSON(http.StatusInternalServerError, marmoset.P{"error": "internal server error"})
 			}

--- a/server/observability/alert.go
+++ b/server/observability/alert.go
@@ -28,14 +28,16 @@ const maxStackLen = 2600
 
 // Report は 1 件のエラーアラートに含める情報。任意項目は空でよい。
 type Report struct {
-	Source    string    // 発生元（例: "frontend", "backend/panic"）
-	Message   string    // エラーメッセージ
-	Stack     string    // スタックトレース
-	URL       string    // 発生 URL / エンドポイント
-	UserAgent string    // クライアント UserAgent
-	Release   string    // ビルド識別子
-	User      string    // Slack ユーザ ID 等
-	Time      time.Time // 発生時刻（zero 値なら送信時刻で補完）
+	Source         string    // 発生元（例: "frontend", "backend/panic"）
+	Message        string    // エラーメッセージ
+	Stack          string    // スタックトレース（JS の minified stack / Go の debug.Stack）
+	ComponentStack string    // React コンポーネントスタック（描画クラッシュの犯人特定に有効）
+	URL            string    // 発生 URL / エンドポイント
+	Referer        string    // 遷移元（任意）
+	UserAgent      string    // クライアント UserAgent
+	Release        string    // ビルド識別子
+	User           string    // Slack ユーザ ID 等
+	Time           time.Time // 発生時刻（zero 値なら送信時刻で補完）
 }
 
 // 同一エラーの短時間連投を抑制するための簡易 dedup 状態。
@@ -115,6 +117,9 @@ func (r Report) blocks() []slack.Block {
 	if r.URL != "" {
 		body += "\n*発生箇所:* `" + r.URL + "`"
 	}
+	if r.Referer != "" {
+		body += "\n*遷移元:* `" + r.Referer + "`"
+	}
 	if r.Release != "" {
 		body += "\n*リリース:* `" + r.Release + "`"
 	}
@@ -126,6 +131,14 @@ func (r Report) blocks() []slack.Block {
 	)
 
 	blocks := []slack.Block{header, meta, msg}
+	// React コンポーネントスタック（描画クラッシュの犯人特定に最も有効）
+	if strings.TrimSpace(r.ComponentStack) != "" {
+		cs := slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, "*コンポーネントスタック:*\n```"+truncate(r.ComponentStack, maxStackLen)+"```", false, false),
+			nil, nil,
+		)
+		blocks = append(blocks, cs)
+	}
 	if strings.TrimSpace(r.Stack) != "" {
 		stack := slack.NewSectionBlock(
 			slack.NewTextBlockObject(slack.MarkdownType, "*スタック:*\n```"+truncate(r.Stack, maxStackLen)+"```", false, false),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,11 @@ const apiBase = `http://localhost:${process.env.VITE_API_PORT ?? '8080'}`
 export default defineConfig({
   plugins: [react()],
   root: 'client',
+  // minify 時も関数名・クラス名を保持する。これによりエラー報告（observability）の
+  // JS スタックと React コンポーネントスタックが本番でも実名で読める（犯人特定に有効）。
+  esbuild: {
+    keepNames: true,
+  },
   build: {
     outDir: 'dest',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

#605 の続き。PR #606 は「基本形」（panic recovery / client-errors API / Error Boundary / 大域ハンドラ）のスナップショット（`fa61804`）で merge されたため、その後に積んだ **「できるだけ詳細に」の核心** が main に未反映だった。本 PR でそれを取り込む。

## Closes

Refs #605, follow-up to #606

## Changes（2 コミット）

- `fe744f2` — **A+B：報告の詳細度を強化**
  - FE: React の **コンポーネントスタック**を取得して報告。`defaultErrorComponent` の props には componentStack が渡らない（空文字固定）ため、`errorInfo` を受け取れる router の `defaultOnCatch` で報告。報告経路を一本化し `ErrorFallback` は表示のみに。
  - BE: panic 報告に **クエリ文字列（RequestURI）・Referer・UserAgent・panic 値の型**を追加。
  - `Report` に `ComponentStack` / `Referer` を追加し Block Kit に整形。client-errors API に `componentStack` 受け口を追加。
- `3f8d281` — **build: esbuild `keepNames: true`**
  - minify 時も関数名・クラス名を保持。これによりコンポーネントスタック／JS スタックが**本番でも実名**で残る（例: `at RSVPModal`）。検証で「現状 bundle は名前を潰している（`RSVPModal` 0 回出現）」ことを確認済み。bundle は gzip +約10KB。

## なぜ必要か

これが無いと、本番の React 描画クラッシュ（#604 級）で飛ぶスタックは minified 名（`at o`）になり「どのコンポーネントで落ちたか」が分からない。本 PR で犯人コンポーネントを名指しできるようになる。

## Test Plan

- [x] [BUILD] `go build ./...` / `npm run build` / `npm run lint` 通過
- [x] [LOGIC] `go test ./...`（`server/api` `server/filters` PASS。client-errors は componentStack を含む body でも 204）
- [x] [LOGIC] keepNames 有効化後、`client/dest/assets/index-*.js` に `RSVPModal` `EventView` 等が実名で残ることを確認（各 1 回出現）
- [ ] [UI][SIDE-EFFECT] 本番相当で描画例外 → Slack 投稿にコンポーネントスタックが**実名**で含まれること（実 Slack 投稿のため手動・dev チャンネルで確認）

## Note

- 行・列番号の完全シンボリケーション（sourcemap 処理）は引き続き未対応（option C / 別途）。本 PR の keepNames + コンポーネントスタックで関数・コンポーネント名は実名になり、実用上の犯人特定は可能。