### PR TITLE
fix(events,uniforms): RSVP/ユニフォームのモーダルを headless-ui v2 idiomatic へ移行（#604 React #130 修正）

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Test
       run: npm run test -- --coverage
     - name: Upload Node.js coverage to Codecov

--- a/.github/workflows/gae-deploy-dev.yml
+++ b/.github/workflows/gae-deploy-dev.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Lint
       run: npm run lint
     - name: Test
@@ -56,7 +56,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Export assets
       run: npm run export
     - name: Auth GCP

--- a/.github/workflows/gae-deploy-prod.yml
+++ b/.github/workflows/gae-deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Lint
       run: npm run lint
     - name: Test
@@ -58,7 +58,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Export assets
       run: npm run export
     - name: Auth GCP

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Lint
       run: npm run lint
     - name: Test

--- a/client/components/Events/RSVPModal/index.tsx
+++ b/client/components/Events/RSVPModal/index.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@headlessui/react";
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
 import { CheckCircleIcon } from "@heroicons/react/outline";
 import { useRef, useState } from "react";
 import { EventDateTime, EventLocation } from "..";
@@ -20,27 +20,26 @@ export function RSVPModal({
     <Dialog
       open={isOpen}
       as="div"
-      className="fixed inset-0 z-10 overflow-y-auto"
+      className="relative z-10"
       onClose={closeModal}
     >
-      <div className="min-h-screen px-4 text-center">
-        <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-40" />
-
-        {/* This element is to trick the browser into centering the modal contents. */}
-        <span className="inline-block h-screen align-middle" aria-hidden="true">&#8203;</span>
-
-        <div
-          className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
-          <EventDateTime timestamp={event.google.start_time} />
-          <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">{event.google.title}</Dialog.Title>
-          <EventLocation location={event.google.location} />
-          <ParticipationSelectBoxes
-            ptype={ptype} defaultTime={defaultTime} setPType={setPType}
-            onCancel={closeModal} onCommit={async ({type, params}) => {
-              await submit({event, answer: type, params});
-              closeModal();
-            }}
-          />
+      {/* 背景クリック・Esc での close は Dialog/DialogPanel が native に処理する */}
+      <DialogBackdrop className="fixed inset-0 bg-black/40" />
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4 text-center">
+          <DialogPanel
+            className="w-full max-w-md p-6 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+            <EventDateTime timestamp={event.google.start_time} />
+            <DialogTitle as="h3" className="text-lg font-medium leading-6 text-gray-900">{event.google.title}</DialogTitle>
+            <EventLocation location={event.google.location} />
+            <ParticipationSelectBoxes
+              ptype={ptype} defaultTime={defaultTime} setPType={setPType}
+              onCancel={closeModal} onCommit={async ({type, params}) => {
+                await submit({event, answer: type, params});
+                closeModal();
+              }}
+            />
+          </DialogPanel>
         </div>
       </div>
     </Dialog>

--- a/client/components/Uniforms/ModalContents.tsx
+++ b/client/components/Uniforms/ModalContents.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@headlessui/react";
+import { DialogPanel, DialogTitle } from "@headlessui/react";
 import Member from "../../models/Member";
 import { PlayerNumber } from "../../models/PlayerNumber";
 import { useState } from "react";
@@ -77,12 +77,12 @@ export function NumAssignModalContent({
 }) {
   const [query, setQuery] = useState("");
   return (
-    <div
-      className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl"
+    <DialogPanel
+      className="w-full max-w-md p-6 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl"
     >
-      <Dialog.Title as="h3" className="font-medium leading-6 text-gray-900 mb-2">
+      <DialogTitle as="h3" className="font-medium leading-6 text-gray-900 mb-2">
         <span>背番号</span> <span className="text-4xl text-red-900 border p-1">{playernumber.number}</span> <span>を選手に割り当てる</span>
-      </Dialog.Title>
+      </DialogTitle>
 
       <div>
         <QueryFieldView query={query} setQuery={setQuery} />
@@ -105,6 +105,6 @@ export function NumAssignModalContent({
       <div>
         <button onClick={close} className="mt-4 bg-red-200 text-gray-800 py-1 px-4 rounded-md">やっぱりやめる</button>
       </div>
-    </div>
+    </DialogPanel>
   );
 }

--- a/client/src/pages/uniforms.tsx
+++ b/client/src/pages/uniforms.tsx
@@ -4,7 +4,7 @@ import { PlayerNumberRepo } from "../../repository/PlayerNumberRepo";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { PlayerNumber } from "../../models/PlayerNumber";
 import Member from "../../models/Member";
-import { Dialog } from "@headlessui/react";
+import { Dialog, DialogBackdrop } from "@headlessui/react";
 import { NumAssignModalContent } from "../../components/Uniforms/ModalContents";
 import { useAppContext } from "../context";
 
@@ -54,13 +54,14 @@ function PlayerNumberListView({ playernumbers, members, loading }: {
       <Dialog
         open={modalContent !== null}
         as="div"
-        className="fixed inset-0 z-10 overflow-y-auto"
+        className="relative z-10"
         onClose={() => setModalContante(null)}
       >
-        <div className="min-h-screen px-4 text-center">
-          <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-40" />
-          <span className="inline-block h-screen align-middle" aria-hidden="true">&#8203;</span>
-          {modalContent}
+        <DialogBackdrop className="fixed inset-0 bg-black/40" />
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            {modalContent}
+          </div>
         </div>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary

本番(headless-ui v2.2.10)で削除済みの `Dialog.Overlay` を使い続けていたため、RSVPModal とユニフォームのモーダル描画時に React #130（Element type is invalid: undefined）でクラッシュしていた（#604）。両モーダルを **v2 公式パターン（`DialogBackdrop`/`DialogPanel`/`DialogTitle`）へ移行**して解消する。あわせて CI/デプロイを `npm ci` に統一し、本番＝lockfile の依存固定で再発を防ぐ。

## Closes

Closes #604

## Changes

- `RSVPModal/index.tsx` / `ModalContents.tsx` / `uniforms.tsx`: `Dialog.Overlay`→`DialogBackdrop`、内側パネル→`DialogPanel`、`Dialog.Title`→`DialogTitle`、旧 min-h-screen+センタリング span を v2 標準の flex センタリングへ。背景クリック・Esc 閉じは Dialog/DialogPanel が native 処理（手動 onClick 不要）。
- workflows ×4（js/coverage/gae-deploy-dev/prod の `npm install` 計6箇所）→ `npm ci`。package.json(`^2.2.10`)と lockfile(`2.2.10`)は整合済みのため安全。

## 設計判断（grill→tackle で改訂）

当初 grill では band-aid（素 div + onClick）に合意したが、オーナー判断で **v2 idiomatic 移行**へ改訂（次回 bump 時の再発リスク低減・閉じ挙動の native 化）。`latest`=2.2.10 で固定済みのためバージョン bump は不要。詳細は Issue #604 の「意思決定事項」。

## Test Plan

> 注: PR 作成時点での Issue #604 `## 受け入れ条件` のスナップショット。source-of-truth は Issue 側。

- [x] [BUILD] `npm ci`(headlessui 2.2.10) で `npm run build` 成功
- [x] [BUILD] CI/デプロイ workflow を `npm ci` に変更（各ジョブの green は本 PR の CI で確認）
- [x] [UI] 「遅参/早退」→ RSVP モーダルが React #130 無しで開く
- [x] [UI][MUTATING] 時刻選択→「これでよし」→ 早退で登録され詳細に反映（参加 1人/早退バッジ）
- [x] [UI] RSVP モーダルが背景クリックで閉じる（＋Esc/キャンセル）
- [x] [UI] 「不参加」「参加」が従来どおり（リグレッション無し）
- [x] [UI] `/uniforms` モーダルも #130 無しで開き背景クリックで閉じる

## Verification

隔離 env（env-provision）+ Playwright（system Chrome, v2.2.10 実インストール）。捕捉した「Element type is invalid」/#130 は **0 件**。

- [UI] RSVP モーダル正常描画（センタリング・バックドロップ）
  ![rsvp-modal](https://github.com/triax/hub/releases/download/uat-evidence/tackle-604-rsvp-modal-overlay-crash-20260610-184303-02-PASS-rsvp-modal-open.png)
- [UI][MUTATING] 早退 登録の反映（参加 1人・遅参/早退 active）
  ![rsvp-submitted](https://github.com/triax/hub/releases/download/uat-evidence/tackle-604-rsvp-modal-overlay-crash-20260610-184303-04-PASS-rsvp-submitted.png)
- [UI] 背景クリックで閉じる
  ![backdrop-close](https://github.com/triax/hub/releases/download/uat-evidence/tackle-604-rsvp-modal-overlay-crash-20260610-184303-03-PASS-rsvp-backdrop-close.png)
- [UI] /uniforms 割当モーダルも正常描画
  ![uniforms-modal](https://github.com/triax/hub/releases/download/uat-evidence/tackle-604-rsvp-modal-overlay-crash-20260610-184303-06-uniforms-modal.png)