### PR TITLE
fix(hp-profile): 写真アップロード先を公開領域 hp/photos/ に変更

### DIFF
--- a/secrets.example.yaml
+++ b/secrets.example.yaml
@@ -21,10 +21,14 @@ env_variables:
   DEEPL_API_TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxx
 
   # HP Photo Storage (GCS)
-  # バケット作成: gsutil mb gs://your-project-hp-photos
-  # 公開アクセス: gsutil iam ch allUsers:objectViewer gs://your-project-hp-photos
-  # IAM: App Engine SA に roles/storage.objectAdmin を付与
-  GCS_HP_PHOTO_BUCKET: your-project-hp-photos
+  # 公開範囲はバケット全体ではなく hp/ マネージドフォルダのみ
+  # （allUsers への条件付き IAM は GCS では使えないため managed folder で代替）。
+  # アップロード先パス hp/photos/... は server/api/hp_profile.go 側で固定。
+  # バケット作成: gcloud storage buckets create gs://your-project --location=asia-northeast1 --uniform-bucket-level-access
+  # 公開フォルダ: gcloud storage managed-folders create gs://your-project/hp/
+  #              gcloud storage managed-folders add-iam-policy-binding gs://your-project/hp/ --member=allUsers --role=roles/storage.objectViewer
+  # 書き込み権限: gcloud storage buckets add-iam-policy-binding gs://your-project --member=serviceAccount:your-project@appspot.gserviceaccount.com --role=roles/storage.objectAdmin
+  GCS_HP_PHOTO_BUCKET: your-project
 
   # Observability（エラーアラート投稿先）
   # フロント／バックエンドの未捕捉エラーを投稿する Slack チャンネル ID。

--- a/server/api/hp_profile.go
+++ b/server/api/hp_profile.go
@@ -126,7 +126,9 @@ func UploadHPPhoto(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	objectName := fmt.Sprintf("hp-profile/%s/%s-%d.%s", id, photoType, time.Now().UnixMilli(), ext)
+	// hp/ プレフィックスは GCS のマネージドフォルダ単位で allUsers:objectViewer を
+	// 付与している公開領域。ここを変える場合はバケットの IAM 設定も合わせること。
+	objectName := fmt.Sprintf("hp/photos/%s/%s-%d.%s", id, photoType, time.Now().UnixMilli(), ext)
 	publicURL, err := uploadToGCS(req.Context(), objectName, detectedMIME, fileData)
 	if err != nil {
 		render.JSON(http.StatusInternalServerError, marmoset.P{"error": err.Error()})


### PR DESCRIPTION
## 背景

プロフィール編集画面で画像アップロードが `GCS_HP_PHOTO_BUCKET is not set` で失敗していた（#560 で導入された環境変数がデプロイ環境の secrets に未設定だったため）。

## GCS 側の対応（実施済み）

- バケット作成: `gs://triax-football`（PROD）/ `gs://triax-football-dev`（DEV）、asia-northeast1、Uniform bucket-level access
- 公開読み取り: `hp/` **マネージドフォルダ**に `allUsers:objectViewer` を付与（`allUsers` への条件付き IAM は GCS では許可されないため、managed folder で公開範囲を限定）
- 書き込み: App Engine SA（`triax-football@appspot.gserviceaccount.com`）に両バケットへ `roles/storage.objectAdmin` を付与
- 検証済み: `hp/` 配下は匿名アクセス 200、配下以外は 403

## このPRの変更

- アップロード先オブジェクトパスを `hp-profile/...` → `hp/photos/<memberID>/...` に変更（旧パスは公開範囲外のため、アップロードは成功しても画像が表示できない）
- `secrets.example.yaml` のセットアップ手順を managed folder 方式に更新

## マージ前に必要な作業（手動）

- [ ] GitHub Secret `APP_SECRETS_DEV_YAML` に `GCS_HP_PHOTO_BUCKET: triax-football-dev` を追記
- [ ] GitHub Secret `APP_SECRETS_PROD_YAML` に `GCS_HP_PHOTO_BUCKET: triax-football` を追記

## Test Plan

- [ ] DEV 環境のプロフィール編集画面で画像アップロードが成功する
- [ ] アップロードされた画像 URL（`https://storage.googleapis.com/triax-football-dev/hp/photos/...`）が匿名で閲覧できる
- [ ] `hp/` 配下以外のオブジェクトは匿名で閲覧できない（403）