### PR TITLE
feat(events): #sponsor タグを新設し EventTag / フィルタ UI に追加

### DIFF
--- a/client/models/TriaxEvent.ts
+++ b/client/models/TriaxEvent.ts
@@ -21,7 +21,7 @@ enum ParticipationType {
   ABSENT = "absent",
 }
 
-export type EventTag = "練習" | "試合" | "event" | "meeting" | "UNKNOWN";
+export type EventTag = "練習" | "試合" | "event" | "meeting" | "sponsor" | "ignore" | "UNKNOWN";
 
 export default class TeamEvent {
   constructor(
@@ -41,6 +41,7 @@ export default class TeamEvent {
     if (/[＃#]試合/.test(t)) return "試合";
     if (/[＃#]event/.test(t)) return "event";
     if (/[＃#]meeting|mtg/.test(t)) return "meeting";
+    if (/[＃#](sponsor|スポンサー)/.test(t)) return "sponsor";
     return "UNKNOWN";
   }
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -12,12 +12,13 @@ import { useAppContext } from "../context";
 const repo = new TeamEventRepo();
 const merepo = new MemberCache();
 
-type FilterKey = "練習" | "試合" | "イベント" | "その他";
+type FilterKey = "練習" | "試合" | "イベント" | "スポンサー" | "その他";
 
 const filters: { key: FilterKey; label: string; tags: EventTag[] }[] = [
   { key: "練習", label: "練習", tags: ["練習"] },
   { key: "試合", label: "試合", tags: ["試合"] },
   { key: "イベント", label: "イベント", tags: ["event"] },
+  { key: "スポンサー", label: "スポンサー", tags: ["sponsor"] },
   { key: "その他", label: "その他", tags: ["meeting", "UNKNOWN"] },
 ];
 

--- a/fixtures/scenarios.go
+++ b/fixtures/scenarios.go
@@ -70,6 +70,7 @@ func defaultScenario(now time.Time) Scenario {
 		{"fixture_event_practice_01", "#練習 第1回 春季練習", -7},
 		{"fixture_event_practice_02", "#練習 第2回 春季練習", -3},
 		{"fixture_event_game_01", "#試合 練習試合 vs Fixtures", 3},
+		{"fixture_event_sponsor_01", "#sponsor スポンサー説明会", 7},
 	}
 	for _, d := range eventDefs {
 		start := now.AddDate(0, 0, d.days)

--- a/fixtures/scenarios.go
+++ b/fixtures/scenarios.go
@@ -71,6 +71,7 @@ func defaultScenario(now time.Time) Scenario {
 		{"fixture_event_practice_02", "#練習 第2回 春季練習", -3},
 		{"fixture_event_game_01", "#試合 練習試合 vs Fixtures", 3},
 		{"fixture_event_sponsor_01", "#sponsor スポンサー説明会", 7},
+		{"fixture_event_sponsor_02", "#スポンサー 協賛企業交流会", 10},
 	}
 	for _, d := range eventDefs {
 		start := now.AddDate(0, 0, d.days)

--- a/server/models/events.go
+++ b/server/models/events.go
@@ -58,6 +58,7 @@ const (
 	ETIgnore   EventTag = "ignore"
 	ETMeeting  EventTag = "meeting"
 	ETEvent    EventTag = "event"
+	ETSponsor  EventTag = "sponsor"
 	ETUnkonwn  EventTag = "UNKNOWN"
 )
 
@@ -67,6 +68,7 @@ var (
 	EventExpressionIgnore   = regexp.MustCompile("[＃#]ignore")
 	EventExpressionEvent    = regexp.MustCompile("[＃#]event")
 	EventExpressionMeeting  = regexp.MustCompile("[＃#]meeting|mtg")
+	EventExpressionSponsor  = regexp.MustCompile("[＃#](sponsor|スポンサー)")
 )
 
 func (pt ParticipationType) String() string {
@@ -110,6 +112,9 @@ func (e Event) ShouldSkipReminders(rt ReminderType) bool {
 	if e.Tag() == ETEvent && rt != RTRSVP {
 		return true // eventは、RSVP以外はskip
 	}
+	if e.Tag() == ETSponsor && rt != RTRSVP {
+		return true // sponsorは、eventと同等: RSVP以外はskip
+	}
 	return false
 }
 
@@ -128,6 +133,9 @@ func (e Event) Tag() EventTag {
 	}
 	if EventExpressionEvent.MatchString(e.Google.Title) {
 		return ETEvent
+	}
+	if EventExpressionSponsor.MatchString(e.Google.Title) {
+		return ETSponsor
 	}
 	return ETUnkonwn
 }

--- a/server/models/events_test.go
+++ b/server/models/events_test.go
@@ -1,0 +1,42 @@
+package models
+
+import "testing"
+
+// TestTagSponsor は #sponsor / #スポンサー / ＃sponsor のタイトルで Tag() が "sponsor" を返すことを確認する。
+func TestTagSponsor(t *testing.T) {
+	cases := []struct {
+		title string
+	}{
+		{"#sponsor 説明会"},
+		{"#スポンサー 説明会"},
+		{"＃sponsor 説明会"},
+		{"2026年 ＃スポンサー 交流イベント"},
+	}
+	for _, c := range cases {
+		ev := Event{}
+		ev.Google.Title = c.title
+		if got := ev.Tag(); got != ETSponsor {
+			t.Errorf("Tag(%q) = %q, want %q", c.title, got, ETSponsor)
+		}
+	}
+}
+
+// TestShouldSkipRemindersSponsor は ETSponsor の ShouldSkipReminders が ETEvent と同じ挙動になることを確認する。
+// - RTRSVP は送信する（skip しない）
+// - RTEquipment / RTCondition / RTFinalCall は skip する
+func TestShouldSkipRemindersSponsor(t *testing.T) {
+	sponsor := Event{}
+	sponsor.Google.Title = "#sponsor 説明会"
+
+	event := Event{}
+	event.Google.Title = "#event 総会"
+
+	reminderTypes := []ReminderType{RTRSVP, RTFinalCall, RTCondition, RTEquipment}
+	for _, rt := range reminderTypes {
+		gotSponsor := sponsor.ShouldSkipReminders(rt)
+		gotEvent := event.ShouldSkipReminders(rt)
+		if gotSponsor != gotEvent {
+			t.Errorf("ShouldSkipReminders(%q) for sponsor=%v, event=%v; want same result", rt, gotSponsor, gotEvent)
+		}
+	}
+}

--- a/server/tasks/rsvp.go
+++ b/server/tasks/rsvp.go
@@ -199,7 +199,7 @@ func CronCheckRSVP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if recent.Tag() != models.ETEvent { // #event は、RSVPリマインダーを送信しなくてよい
+	if recent.Tag() != models.ETEvent && recent.Tag() != models.ETSponsor { // #event / #sponsor は未回答者メンションをスキップ
 		reminder := buildRSVPReminderMentionMessage(recent, x["unanswered"])
 		if _, _, err := api.PostMessage("#"+channel, reminder, slack.MsgOptionTS(ts)); err != nil {
 			log.Println("[ERROR]", 4008, err.Error())


### PR DESCRIPTION
Closes #610

## 背景

スポンサー対応イベントを Google Calendar のタイトルに `#sponsor` / `#スポンサー` で記録しても、既存のタグ判定に該当するものがなく `UNKNOWN` 扱いになっていた。その結果フィルタ UI の「その他」に埋もれ、スポンサーイベントだけを絞り込む手段がなかった。また棚卸しで frontend の `EventTag` 型に `"ignore"` が欠落していることも確認された。

## 目的

スポンサーイベントを専用タグ `sponsor` で識別できるようにし、スケジュールページで「スポンサー」フィルタタブから絞り込めるようにする。リマインダー挙動は `#event` と同等（RSVP は送信、備品・コンディショニング等はスキップ）とし、既存の他タグ挙動に影響を与えない。

## 方針

タグ判定は backend / frontend 二重定義の既存構造をそのまま踏襲した（二重化解消は Issue に記載の将来課題として保留）。新タグの挙動を `event` と同等にすることで追加のルール実装を最小化した。

`Tag()` のマッチ順序は `event` の後に `sponsor` を配置した。`#event` と `#sponsor` が同時に含まれるタイトルは `event` 優先になるが、実運用上そのようなタイトルは想定しないため許容した。

## 設計

| ファイル | 変更内容 | AC |
|--------|---------|-----|
| `server/models/events.go` | `ETSponsor` 定数・`EventExpressionSponsor` 正規表現を追加。`Tag()` に sponsor 分岐追加。`ShouldSkipReminders()` に ETSponsor を ETEvent と同等の条件で追加 | AC-1, AC-2 |
| `server/tasks/rsvp.go` | 未回答者メンションスキップ条件に `ETSponsor` を追加 | AC-2 |
| `client/models/TriaxEvent.ts` | `EventTag` union 型に `"sponsor"` と欠落していた `"ignore"` を追加。`tag()` に sponsor 判定正規表現を追加 | AC-1 |
| `client/src/pages/index.tsx` | `FilterKey` と `filters` 定義に「スポンサー」タブを追加 | AC-3 |
| `fixtures/scenarios.go` | `#sponsor スポンサー説明会` フィクスチャを 1 件追加 | AC-3, AC-4 |
| `server/models/events_test.go` | `Tag()` / `ShouldSkipReminders()` の Go unit test を追加 | AC-1, AC-2 |

## 受入条件

- [x] [LOGIC] Go ユニットテスト: タイトル `#sponsor 説明会` / `#スポンサー 説明会` / `＃sponsor 説明会` で `Tag()` が `sponsor` を返す
- [x] [LOGIC] Go ユニットテスト: `ETSponsor` の `ShouldSkipReminders()` が `ETEvent` と同じ結果を返す（備品・コンディショニングはスキップ、RSVP は送る）
- [ ] [UI] スケジュールページのフィルタに「スポンサー」タブが表示され、ON にすると `#sponsor` イベントのみ表示される
- [ ] [UI] `#スポンサー` 表記のイベントも同様に「スポンサー」フィルタで表示される
- [ ] [UI] 既存タグ（#練習 / #試合 / #event）のフィルタ挙動にデグレがない
- [x] [BUILD] `go build -v ./...` と `go test ./...` が通ること
- [x] [BUILD] `npm run build` と `npm run lint` が通ること

## 評価観点

- `Tag()` のマッチ順序: `sponsor` を `event` の後に置いたため、タイトルに両方含む場合は `event` 優先になる。これが意図に合っているか確認してほしい
- `"ignore"` の frontend 欠落補完: 本 Issue のメイン要件ではないが、棚卸しで発見したため同梱した。`filterEvents()` に `"ignore"` を許可タグとして加えると「除外」イベントが表示される恐れがあるため、filters 定義には追加していない（型だけ補完）

## 発見

- frontend `EventTag` 型から `"ignore"` が欠落していた（backend は `ETIgnore = "ignore"` が定義済み）。型のみ補完し、フィルタ UI には追加していない（`#ignore` イベントは fetch 時点で除外される仕様のため）
