### PR TITLE
feat(events): イベントタグを複数タグ対応に（全 #tag を反映）

### DIFF
--- a/client/components/Events/index.tsx
+++ b/client/components/Events/index.tsx
@@ -60,7 +60,7 @@ export function EventRow({ event, myself, submit, setModalEvent, navigate }) {
   const pats = event.participations;
   const answer = pats[myself.slack.id] || {};
   const id = event.google.id.replace(/@google\.com$/, "");
-  if (event.tags().includes("ignore")) return null; // #ignore を含む行は一覧から非表示（位置・全半角不問）
+  if (event.hasTag("ignore")) return null; // #ignore を含む行は一覧から非表示（位置・全半角不問）
   return (
     <div className={"px-0 py-4 " + (event.google.start_time < Date.now() ? "bg-slate-200" : "")}>
       <div onClick={() => navigate({ to: `/events/${id}` })}>

--- a/client/components/Events/index.tsx
+++ b/client/components/Events/index.tsx
@@ -60,7 +60,7 @@ export function EventRow({ event, myself, submit, setModalEvent, navigate }) {
   const pats = event.participations;
   const answer = pats[myself.slack.id] || {};
   const id = event.google.id.replace(/@google\.com$/, "");
-  if (event.google?.title?.match(/#ignore$/)) return null;
+  if (event.tags().includes("ignore")) return null; // #ignore を含む行は一覧から非表示（位置・全半角不問）
   return (
     <div className={"px-0 py-4 " + (event.google.start_time < Date.now() ? "bg-slate-200" : "")}>
       <div onClick={() => navigate({ to: `/events/${id}` })}>

--- a/client/models/TriaxEvent.ts
+++ b/client/models/TriaxEvent.ts
@@ -35,13 +35,19 @@ export default class TeamEvent {
   static placeholder(): TeamEvent {
     return new TeamEvent({ id: '', title: 'xx', location: 'xxx', start_time: 0, end_time: 0 }, {});
   }
-  tag(): EventTag {
+  // tags はタイトルに含まれる全てのタグを返す（複数タグ対応）。
+  // 該当タグが無ければ "UNKNOWN" ひとつを返す。
+  // 判定順序はサーバ events.go の Tags() と一致させること。
+  tags(): EventTag[] {
     const t = this.google.title;
-    if (/[＃#]練習/.test(t)) return "練習";
-    if (/[＃#]試合/.test(t)) return "試合";
-    if (/[＃#]event/.test(t)) return "event";
-    if (/[＃#]meeting|mtg/.test(t)) return "meeting";
-    if (/[＃#](sponsor|スポンサー)/.test(t)) return "sponsor";
-    return "UNKNOWN";
+    const result: EventTag[] = [];
+    if (/[＃#]練習/.test(t)) result.push("練習");
+    if (/[＃#]試合/.test(t)) result.push("試合");
+    if (/[＃#]ignore/.test(t)) result.push("ignore");
+    if (/[＃#](meeting|mtg)/.test(t)) result.push("meeting");
+    if (/[＃#]event/.test(t)) result.push("event");
+    if (/[＃#](sponsor|スポンサー)/.test(t)) result.push("sponsor");
+    if (result.length === 0) result.push("UNKNOWN");
+    return result;
   }
 }

--- a/client/models/TriaxEvent.ts
+++ b/client/models/TriaxEvent.ts
@@ -23,6 +23,17 @@ enum ParticipationType {
 
 export type EventTag = "練習" | "試合" | "event" | "meeting" | "sponsor" | "ignore" | "UNKNOWN";
 
+// TAG_PATTERNS はタグ判定の唯一の定義（判定順序込み）。
+// サーバ events.go の tagDefs と順序・正規表現を一致させること。
+const TAG_PATTERNS: { tag: EventTag; re: RegExp }[] = [
+  { tag: "練習", re: /[＃#]練習/ },
+  { tag: "試合", re: /[＃#]試合/ },
+  { tag: "ignore", re: /[＃#]ignore/ },
+  { tag: "meeting", re: /[＃#](meeting|mtg)/ },
+  { tag: "event", re: /[＃#]event/ },
+  { tag: "sponsor", re: /[＃#](sponsor|スポンサー)/ },
+];
+
 export default class TeamEvent {
   constructor(
       public google: GoogleEvent,
@@ -37,17 +48,12 @@ export default class TeamEvent {
   }
   // tags はタイトルに含まれる全てのタグを返す（複数タグ対応）。
   // 該当タグが無ければ "UNKNOWN" ひとつを返す。
-  // 判定順序はサーバ events.go の Tags() と一致させること。
   tags(): EventTag[] {
-    const t = this.google.title;
-    const result: EventTag[] = [];
-    if (/[＃#]練習/.test(t)) result.push("練習");
-    if (/[＃#]試合/.test(t)) result.push("試合");
-    if (/[＃#]ignore/.test(t)) result.push("ignore");
-    if (/[＃#](meeting|mtg)/.test(t)) result.push("meeting");
-    if (/[＃#]event/.test(t)) result.push("event");
-    if (/[＃#](sponsor|スポンサー)/.test(t)) result.push("sponsor");
-    if (result.length === 0) result.push("UNKNOWN");
-    return result;
+    const result = TAG_PATTERNS.filter(p => p.re.test(this.google.title)).map(p => p.tag);
+    return result.length ? result : ["UNKNOWN"];
+  }
+  // hasTag は指定タグがタイトルに含まれるかを返す（tags() と一貫）。
+  hasTag(tag: EventTag): boolean {
+    return this.tags().includes(tag);
   }
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -29,7 +29,7 @@ function filterEvents(events: TeamEvent[], active: Set<FilterKey>): TeamEvent[] 
   for (const f of filters) {
     if (active.has(f.key)) f.tags.forEach(t => allowedTags.add(t));
   }
-  return events.filter(ev => allowedTags.has(ev.tag()));
+  return events.filter(ev => ev.tags().some(t => allowedTags.has(t)));
 }
 
 export default function Top() {

--- a/fixtures/scenarios.go
+++ b/fixtures/scenarios.go
@@ -72,6 +72,7 @@ func defaultScenario(now time.Time) Scenario {
 		{"fixture_event_game_01", "#試合 練習試合 vs Fixtures", 3},
 		{"fixture_event_sponsor_01", "#sponsor スポンサー説明会", 7},
 		{"fixture_event_sponsor_02", "#スポンサー 協賛企業交流会", 10},
+		{"fixture_event_practice_sponsor_01", "#練習 #sponsor 合同練習＆協賛社見学", 5},
 	}
 	for _, d := range eventDefs {
 		start := now.AddDate(0, 0, d.days)

--- a/server/models/events.go
+++ b/server/models/events.go
@@ -67,7 +67,7 @@ var (
 	EventExpressionGame     = regexp.MustCompile("[＃#]試合")
 	EventExpressionIgnore   = regexp.MustCompile("[＃#]ignore")
 	EventExpressionEvent    = regexp.MustCompile("[＃#]event")
-	EventExpressionMeeting  = regexp.MustCompile("[＃#]meeting|mtg")
+	EventExpressionMeeting  = regexp.MustCompile("[＃#](meeting|mtg)")
 	EventExpressionSponsor  = regexp.MustCompile("[＃#](sponsor|スポンサー)")
 )
 
@@ -95,49 +95,80 @@ func (e Event) Participations() (Participations, error) {
 }
 
 func (e Event) IsPractice() bool {
-	return e.Tag() == ETPractice
+	return e.HasTag(ETPractice)
 }
 
 func (e Event) IsGame() bool {
-	return e.Tag() == ETGame
+	return e.HasTag(ETGame)
 }
 
 func (e Event) ShouldSkipReminders(rt ReminderType) bool {
-	if e.Tag() == ETIgnore {
-		return true
+	tags := e.Tags()
+	// #ignore は最優先: 含まれていれば全リマインダを skip する（明示オプトアウト）
+	for _, t := range tags {
+		if t == ETIgnore {
+			return true
+		}
 	}
-	if e.Tag() == ETMeeting {
-		return true
+	// most-permissive: いずれかのタグが当該リマインダの送信を望むなら送信する
+	// （= 全タグが skip と判断したときのみ skip する）
+	for _, t := range tags {
+		if !tagSkipsReminder(t, rt) {
+			return false
+		}
 	}
-	if e.Tag() == ETEvent && rt != RTRSVP {
-		return true // eventは、RSVP以外はskip
-	}
-	if e.Tag() == ETSponsor && rt != RTRSVP {
-		return true // sponsorは、eventと同等: RSVP以外はskip
-	}
-	return false
+	return true
 }
 
-func (e Event) Tag() EventTag {
+// tagSkipsReminder は単一タグが当該リマインダ種別を skip すべきかを返す。
+func tagSkipsReminder(t EventTag, rt ReminderType) bool {
+	switch t {
+	case ETIgnore, ETMeeting:
+		return true // ignore / meeting は全リマインダを skip
+	case ETEvent, ETSponsor:
+		return rt != RTRSVP // event / sponsor は RSVP 以外を skip
+	default:
+		return false // 練習 / 試合 / UNKNOWN は skip しない
+	}
+}
+
+// Tags はタイトルに含まれる全てのタグを返す（複数タグ対応）。
+// 該当タグが無ければ ETUnkonwn ひとつを返す。
+// 判定順序はクライアント TriaxEvent.ts の tags() と一致させること。
+func (e Event) Tags() []EventTag {
+	tags := []EventTag{}
 	if EventExpressionPractice.MatchString(e.Google.Title) {
-		return ETPractice
+		tags = append(tags, ETPractice)
 	}
 	if EventExpressionGame.MatchString(e.Google.Title) {
-		return ETGame
+		tags = append(tags, ETGame)
 	}
 	if EventExpressionIgnore.MatchString(e.Google.Title) {
-		return ETIgnore
+		tags = append(tags, ETIgnore)
 	}
 	if EventExpressionMeeting.MatchString(e.Google.Title) {
-		return ETMeeting
+		tags = append(tags, ETMeeting)
 	}
 	if EventExpressionEvent.MatchString(e.Google.Title) {
-		return ETEvent
+		tags = append(tags, ETEvent)
 	}
 	if EventExpressionSponsor.MatchString(e.Google.Title) {
-		return ETSponsor
+		tags = append(tags, ETSponsor)
 	}
-	return ETUnkonwn
+	if len(tags) == 0 {
+		tags = append(tags, ETUnkonwn)
+	}
+	return tags
+}
+
+// HasTag は指定タグがタイトルに含まれるかを返す。
+func (e Event) HasTag(t EventTag) bool {
+	for _, tag := range e.Tags() {
+		if tag == t {
+			return true
+		}
+	}
+	return false
 }
 
 func (t ParticipationType) JoinAnyhow() bool {

--- a/server/models/events.go
+++ b/server/models/events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -132,28 +133,28 @@ func tagSkipsReminder(t EventTag, rt ReminderType) bool {
 	}
 }
 
+// tagDefs はタグ判定の唯一の定義（判定順序込み）。Tags() / HasTag() はこれを回す。
+// クライアント TriaxEvent.ts の TAG_PATTERNS と順序・正規表現を一致させること。
+var tagDefs = []struct {
+	tag EventTag
+	re  *regexp.Regexp
+}{
+	{ETPractice, EventExpressionPractice},
+	{ETGame, EventExpressionGame},
+	{ETIgnore, EventExpressionIgnore},
+	{ETMeeting, EventExpressionMeeting},
+	{ETEvent, EventExpressionEvent},
+	{ETSponsor, EventExpressionSponsor},
+}
+
 // Tags はタイトルに含まれる全てのタグを返す（複数タグ対応）。
 // 該当タグが無ければ ETUnkonwn ひとつを返す。
-// 判定順序はクライアント TriaxEvent.ts の tags() と一致させること。
 func (e Event) Tags() []EventTag {
 	tags := []EventTag{}
-	if EventExpressionPractice.MatchString(e.Google.Title) {
-		tags = append(tags, ETPractice)
-	}
-	if EventExpressionGame.MatchString(e.Google.Title) {
-		tags = append(tags, ETGame)
-	}
-	if EventExpressionIgnore.MatchString(e.Google.Title) {
-		tags = append(tags, ETIgnore)
-	}
-	if EventExpressionMeeting.MatchString(e.Google.Title) {
-		tags = append(tags, ETMeeting)
-	}
-	if EventExpressionEvent.MatchString(e.Google.Title) {
-		tags = append(tags, ETEvent)
-	}
-	if EventExpressionSponsor.MatchString(e.Google.Title) {
-		tags = append(tags, ETSponsor)
+	for _, d := range tagDefs {
+		if d.re.MatchString(e.Google.Title) {
+			tags = append(tags, d.tag)
+		}
 	}
 	if len(tags) == 0 {
 		tags = append(tags, ETUnkonwn)
@@ -162,13 +163,9 @@ func (e Event) Tags() []EventTag {
 }
 
 // HasTag は指定タグがタイトルに含まれるかを返す。
+// Tags() と一貫させるため、タグ無し時の ETUnkonwn も正しく判定できる。
 func (e Event) HasTag(t EventTag) bool {
-	for _, tag := range e.Tags() {
-		if tag == t {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(e.Tags(), t)
 }
 
 func (t ParticipationType) JoinAnyhow() bool {

--- a/server/models/events_test.go
+++ b/server/models/events_test.go
@@ -2,22 +2,48 @@ package models
 
 import "testing"
 
-// TestTagSponsor は #sponsor / #スポンサー / ＃sponsor のタイトルで Tag() が "sponsor" を返すことを確認する。
-func TestTagSponsor(t *testing.T) {
+// TestTagsSingle は単一タグのタイトルで Tags() が該当タグを含むことを確認する。
+func TestTagsSingle(t *testing.T) {
 	cases := []struct {
 		title string
+		want  EventTag
 	}{
-		{"#sponsor 説明会"},
-		{"#スポンサー 説明会"},
-		{"＃sponsor 説明会"},
-		{"2026年 ＃スポンサー 交流イベント"},
+		{"#sponsor 説明会", ETSponsor},
+		{"#スポンサー 説明会", ETSponsor},
+		{"＃sponsor 説明会", ETSponsor},
+		{"2026年 ＃スポンサー 交流イベント", ETSponsor},
+		{"#練習 春季", ETPractice},
+		{"#試合 vs X", ETGame},
+		{"#event 総会", ETEvent},
+		{"#meeting 定例", ETMeeting},
+		{"#mtg 定例", ETMeeting},
+		{"#ignore テスト", ETIgnore},
+		{"タグなしイベント", ETUnkonwn},
 	}
 	for _, c := range cases {
 		ev := Event{}
 		ev.Google.Title = c.title
-		if got := ev.Tag(); got != ETSponsor {
-			t.Errorf("Tag(%q) = %q, want %q", c.title, got, ETSponsor)
+		if !ev.HasTag(c.want) {
+			t.Errorf("Tags(%q) = %v, want to contain %q", c.title, ev.Tags(), c.want)
 		}
+	}
+}
+
+// TestTagsMultiple は複数タグ併記のタイトルで Tags() が全タグを返すことを確認する。
+func TestTagsMultiple(t *testing.T) {
+	ev := Event{}
+	ev.Google.Title = "#練習 #sponsor 合同練習＆協賛社見学"
+	if !ev.HasTag(ETPractice) || !ev.HasTag(ETSponsor) {
+		t.Errorf("Tags(%q) = %v, want to contain both %q and %q", ev.Google.Title, ev.Tags(), ETPractice, ETSponsor)
+	}
+}
+
+// TestTagsMtgFalsePositive は # の無い "mtg" 部分文字列が meeting に誤判定されないことを確認する。
+func TestTagsMtgFalsePositive(t *testing.T) {
+	ev := Event{}
+	ev.Google.Title = "important mtg notes" // # が無い
+	if ev.HasTag(ETMeeting) {
+		t.Errorf("Tags(%q) = %v, must not contain %q (# が無いため)", ev.Google.Title, ev.Tags(), ETMeeting)
 	}
 }
 
@@ -37,6 +63,43 @@ func TestShouldSkipRemindersSponsor(t *testing.T) {
 		gotEvent := event.ShouldSkipReminders(rt)
 		if gotSponsor != gotEvent {
 			t.Errorf("ShouldSkipReminders(%q) for sponsor=%v, event=%v; want same result", rt, gotSponsor, gotEvent)
+		}
+	}
+}
+
+// TestShouldSkipRemindersMultiTag は複数タグ併記時の precedence を確認する:
+// - #ignore が含まれていれば全 rt で skip（最優先）
+// - それ以外は most-permissive（いずれかのタグが送信を望めば送信）
+func TestShouldSkipRemindersMultiTag(t *testing.T) {
+	allTypes := []ReminderType{RTRSVP, RTFinalCall, RTCondition, RTEquipment}
+
+	// #練習 #sponsor: 練習が全リマインダを望む → どの rt でも skip しない
+	practiceSponsor := Event{}
+	practiceSponsor.Google.Title = "#練習 #sponsor 合同練習"
+	for _, rt := range allTypes {
+		if practiceSponsor.ShouldSkipReminders(rt) {
+			t.Errorf("#練習 #sponsor ShouldSkipReminders(%q) = true, want false (練習相当で全送信)", rt)
+		}
+	}
+
+	// #ignore #練習: ignore 最優先 → 全 rt で skip
+	ignorePractice := Event{}
+	ignorePractice.Google.Title = "#ignore #練習 テスト"
+	for _, rt := range allTypes {
+		if !ignorePractice.ShouldSkipReminders(rt) {
+			t.Errorf("#ignore #練習 ShouldSkipReminders(%q) = false, want true (ignore 最優先で全 skip)", rt)
+		}
+	}
+
+	// #meeting #event: RTRSVP のみ送信、それ以外は skip
+	meetingEvent := Event{}
+	meetingEvent.Google.Title = "#meeting #event 総会"
+	if meetingEvent.ShouldSkipReminders(RTRSVP) {
+		t.Errorf("#meeting #event ShouldSkipReminders(RTRSVP) = true, want false (RSVP は送信)")
+	}
+	for _, rt := range []ReminderType{RTFinalCall, RTCondition, RTEquipment} {
+		if !meetingEvent.ShouldSkipReminders(rt) {
+			t.Errorf("#meeting #event ShouldSkipReminders(%q) = false, want true (非 RSVP は skip)", rt)
 		}
 	}
 }

--- a/server/tasks/rsvp.go
+++ b/server/tasks/rsvp.go
@@ -199,7 +199,7 @@ func CronCheckRSVP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if recent.Tag() != models.ETEvent && recent.Tag() != models.ETSponsor { // #event / #sponsor は未回答者メンションをスキップ
+	if !recent.HasTag(models.ETEvent) && !recent.HasTag(models.ETSponsor) { // #event / #sponsor を含むイベントは未回答者メンションをスキップ
 		reminder := buildRSVPReminderMentionMessage(recent, x["unanswered"])
 		if _, _, err := api.PostMessage("#"+channel, reminder, slack.MsgOptionTS(ts)); err != nil {
 			log.Println("[ERROR]", 4008, err.Error())


### PR DESCRIPTION
## 概要

イベントタイトルに `#tag` が2つ以上あっても**最初の1つしか反映されない**問題を解消し、複数タグ対応にする。

Closes #615

## 変更点

| ファイル | 変更 |
|---|---|
| `server/models/events.go` | `Tag()` を撤去し `Tags() []EventTag` / `HasTag()` を新設。`ShouldSkipReminders` を Tags ベースに（**precedence: `#ignore` 最優先で全 skip → 他は most-permissive**）。`IsPractice`/`IsGame` を包含判定に。`mtg` 正規表現を `[＃#](meeting|mtg)` に是正 |
| `server/tasks/rsvp.go` | 未回答者メンションのスキップを `HasTag(ETEvent)`/`HasTag(ETSponsor)` に |
| `client/models/TriaxEvent.ts` | `tag()` → `tags(): EventTag[]`。`#ignore` 判定を追加し、判定順序・`mtg` をサーバと統一 |
| `client/src/pages/index.tsx` | `filterEvents` を `ev.tags().some(t => allowedTags.has(t))` に |
| `client/components/Events/index.tsx` | 一覧非表示を `tags().includes("ignore")` に統一（位置・全半角不問） |
| `fixtures/scenarios.go` | `#練習 #sponsor` の複数タグ fixture を追加 |
| `server/models/events_test.go` | `Tags()`/`HasTag()`/precedence の unit test を追加 |

## 意思決定（#615 grill で確定）

1. リマインダ precedence = `#ignore` 最優先で全 skip → 他は most-permissive
2. `#ignore` の一覧非表示は `tags()` 包含判定に統一（位置/全半角不問）
3. `Tag()`（単数）は撤去し全 caller を `Tags()` へ移行

## 検証結果

- [x] [LOGIC] `#練習 #sponsor` の `Tags()` が `ETPractice`/`ETSponsor` 両方を含む（`TestTagsMultiple`）
- [x] [LOGIC] `ShouldSkipReminders`: `#練習 #sponsor`=全送信 / `#ignore #練習`=全 skip / `#meeting #event`=RSVP のみ送信（`TestShouldSkipRemindersMultiTag`）
- [x] [LOGIC] `mtg`（`#` 無し）が meeting に誤判定されない（`TestTagsMtgFalsePositive`）
- [x] [LOGIC] サーバ `Tags()` とクライアント `tags()` の判定順序・対象タグを統一（コードレビューで確認、クライアント test 基盤なし）
- [x] [BUILD] `go build ./...` / `go test ./...` / `npm run lint` / `npm run build` / `npm run test` すべて通過
- [ ] [UI] トップ `/` でスポンサーフィルタ ON 時に `#練習 #sponsor` イベントが表示される（要手動 UAT）
- [ ] [UI] `#ignore` を先頭・中間・全角(`＃ignore`)で含むイベントが一覧非表示になる（要手動 UAT）

> [!NOTE]
> env_provisioner 未宣言のため [UI] 項目は自動 UAT 不可。手動確認が必要です。
