### PR TITLE
feat(events): 「スポンサー」タブをデフォルトで選択状態にする

### DIFF
--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -22,7 +22,7 @@ const filters: { key: FilterKey; label: string; tags: EventTag[] }[] = [
   { key: "その他", label: "その他", tags: ["meeting", "UNKNOWN"] },
 ];
 
-const defaultFilters: Set<FilterKey> = new Set(["練習", "試合", "イベント"]);
+const defaultFilters: Set<FilterKey> = new Set(["練習", "試合", "スポンサー"]);
 
 function filterEvents(events: TeamEvent[], active: Set<FilterKey>): TeamEvent[] {
   const allowedTags = new Set<EventTag>();


### PR DESCRIPTION
## 概要

トップ「近日中の予定」(`/`) のフィルタチップの初期選択（`defaultFilters`）を見直す（前田さんからの Slack 要望 + デフォルト構成の調整）。

```diff
-const defaultFilters: Set<FilterKey> = new Set(["練習", "試合", "イベント"]);
+const defaultFilters: Set<FilterKey> = new Set(["練習", "試合", "スポンサー"]);
```

- **「スポンサー」を追加** → `#sponsor` イベントが読み込み直後から表示される（#614 本体）
- **「イベント」をデフォルト選択から除外** → `#event` 系イベントは初期表示されなくなる（追加調整）

Closes #614

## 補足

- フィルタは 100% クライアント側。初期表示を制御しているのは `defaultFilters` のみ（バックエンド・localStorage・クエリパラメータでの除外なし）。
- 「イベント」「その他」チップは引き続き存在し、タップすれば表示できる（トグル動作は不変）。
- 元 Issue #614 の受け入れ条件は「スポンサー追加」が主旨で、「イベント除外」はレビュー時の追加判断。スコープが広がっている点に留意。

## #615 との関係

main には既に #615（複数タグ対応 / PR #616）がマージ済み。本 PR と合わせて「デフォルトで sponsor が出る × `#練習 #sponsor` 等の併記イベントも漏れず拾える」最終形になる。

## 検証

- [x] [BUILD] `npm run build` 通過 / `npm run lint` 通過
- [ ] [UI] トップ `/` 読み込み直後に「スポンサー」チップが選択状態（青背景）で、`#sponsor` イベントが表示される
- [ ] [UI] 「イベント」チップは初期 OFF（グレー）で、`#event` イベントが初期一覧に出ない
- [ ] [UI] 各チップのトグルが従来どおり機能する

> [!NOTE]
> env_provisioner 未宣言のため [UI] は自動 UAT 不可。DEV デプロイ後 or `npm run dev` で手動確認が必要です。
